### PR TITLE
adding warnings for save to file and debug mode.

### DIFF
--- a/src/confcom/azext_confcom/_help.py
+++ b/src/confcom/azext_confcom/_help.py
@@ -86,8 +86,8 @@ helps[
           text: az confcom acipolicygen --template-file "./template.json"
         - name: Input an ARM Template file to create a human-readable Confidential Container Security Policy
           text: az confcom acipolicygen --template-file "./template.json" --outraw-pretty-print
-        - name: Input an ARM Template file to save a Confidential Container Security Policy to a file
-          text: az confcom acipolicygen --template-file "./template.json" -s "./output-file.txt"
+        - name: Input an ARM Template file to save a Confidential Container Security Policy to a file as base64 encoded text
+          text: az confcom acipolicygen --template-file "./template.json" -s "./output-file.txt" --print-policy
         - name: Input an ARM Template file and use a tar file as the image source instead of the Docker daemon
           text: az confcom acipolicygen --template-file "./template.json" --tar "./image.tar"
 """

--- a/src/confcom/azext_confcom/template_util.py
+++ b/src/confcom/azext_confcom/template_util.py
@@ -399,7 +399,10 @@ def replace_params_and_vars(params: dict, vars_dict: dict, attribute):
         full_param_name = next(param_name, None)
         if full_param_name:
             full_param_name = full_param_name.group(0)
-            out = attribute.replace(full_param_name, find_value_in_params_and_vars(params, vars_dict, attribute))
+            # cast to string
+            out = f"{out}"
+            out = attribute.replace(full_param_name, out)
+
     elif isinstance(attribute, list):
         out = []
         for item in attribute:
@@ -791,6 +794,8 @@ def get_container_group_name(
 
 
 def print_existing_policy_from_arm_template(arm_template_path, parameter_data_path):
+    if not arm_template_path:
+        eprint("Can only print existing policy from ARM Template")
     input_arm_json = os_util.load_json_from_file(arm_template_path)
     parameter_data = None
     if parameter_data_path:


### PR DESCRIPTION
Adding warnings to say save-to-file is being deprecated and debug mode should not be used outside of debugging.

Fixed bug with numbers for template parameters. There was a bug where if you had a number for a parameter value, the string.replace() operation would error out. By casting the number to a string, this is solved.