### PR TITLE
making rootfs proxy work with upcoming dmverity changes

### DIFF
--- a/src/confcom/azext_confcom/rootfs_proxy.py
+++ b/src/confcom/azext_confcom/rootfs_proxy.py
@@ -121,9 +121,8 @@ class SecurityPolicyProxy:  # pylint: disable=too-few-public-methods
         if outputlines is None:
             eprint("Null pointer detected.")
         elif len(outputlines) > 0:
-            output = outputlines.decode("utf8").rstrip("\n").split("\n")
-            output = [output[j * 2 + 1] for j in range(len(output) // 2)]
-            output = [i.rstrip("\n").split(": ", 1)[1] for i in output]
+            output = outputlines.decode("utf8").strip("\n").split("\n")
+            output = [i.split(": ", 1)[1]  for i in output if len(i.split(": ", 1)) > 1]
         else:
             eprint(
                 "Cannot get layer hashes"


### PR DESCRIPTION
[this PR in hcsshim](https://github.com/microsoft/hcsshim/pull/1770) changes the output format of the dmverity-vhd tool so there are fewer newlines. This PR makes it so that our tooling can handle that change while still being backwards compatible with the older format.