### PR TITLE
getting rid of pydash

### DIFF
--- a/src/confcom/requirements.txt
+++ b/src/confcom/requirements.txt
@@ -2,4 +2,3 @@ docker
 tqdm
 azure-devtools
 deepdiff
-pydash

--- a/src/confcom/setup.py
+++ b/src/confcom/setup.py
@@ -35,7 +35,7 @@ CLASSIFIERS = [
     "License :: OSI Approved :: MIT License",
 ]
 
-DEPENDENCIES = ["docker", "tqdm", "deepdiff", "pydash"]
+DEPENDENCIES = ["docker", "tqdm", "deepdiff"]
 
 SecurityPolicyProxy.download_binaries()
 


### PR DESCRIPTION
pydash is incompatible with an upcoming version of the az cli so we need to either get rid of it or find a version that is compatible. The functions we were using are easy enough to recreate so I opted for getting rid of the dependency.