### PR TITLE
setting version numbers for dependencies

### DIFF
--- a/src/confcom/setup.py
+++ b/src/confcom/setup.py
@@ -35,7 +35,11 @@ CLASSIFIERS = [
     "License :: OSI Approved :: MIT License",
 ]
 
-DEPENDENCIES = ["docker", "tqdm", "deepdiff"]
+DEPENDENCIES = [
+    "docker==6.0.1",
+    "tqdm==4.65.0",
+    "deepdiff==6.3.0"
+]
 
 SecurityPolicyProxy.download_binaries()
 


### PR DESCRIPTION
DeepDiff broke with version 6.4.0 so we're setting it back to a known good version. Also setting other dependencies to known good versions for better reliability