### PR TITLE
making some tests run quicker

### DIFF
--- a/src/confcom/azext_confcom/tests/latest/test_confcom_scenario.py
+++ b/src/confcom/azext_confcom/tests/latest/test_confcom_scenario.py
@@ -28,7 +28,7 @@ class MountEnforcement(unittest.TestCase):
         "version": "1.0",
         "containers": [
             {
-                "containerImage": "rust:1.52.1",
+                "containerImage": "alpine:3.16",
                 "environmentVariables": [
                     {
                         "name": "PATH",
@@ -51,7 +51,7 @@ class MountEnforcement(unittest.TestCase):
                 ]
             },
             {
-                "containerImage": "python:3.6.14-slim-buster",
+                "containerImage": "nginx:1.24",
                 "environmentVariables": [],
                 "command": ["echo", "hello"],
                 "workingDir": "/customized/absolute/path",
@@ -76,7 +76,7 @@ class MountEnforcement(unittest.TestCase):
             (
                 img
                 for img in self.aci_policy.get_images()
-                if isinstance(img, UserContainerImage) and img.base == "rust"
+                if isinstance(img, UserContainerImage) and img.base == "alpine"
             ),
             None,
         )
@@ -115,7 +115,7 @@ class MountEnforcement(unittest.TestCase):
             (
                 img
                 for img in self.aci_policy.get_images()
-                if isinstance(img, UserContainerImage) and img.base == "python"
+                if isinstance(img, UserContainerImage) and img.base == "nginx"
             ),
             None,
         )

--- a/src/confcom/azext_confcom/tests/latest/test_confcom_tar.py
+++ b/src/confcom/azext_confcom/tests/latest/test_confcom_tar.py
@@ -10,7 +10,7 @@ import pytest
 import deepdiff
 import json
 import docker
-import shutil
+
 import threading
 from azext_confcom.security_policy import (
     OutputType,

--- a/src/confcom/azext_confcom/tests/latest/test_confcom_template_util.py
+++ b/src/confcom/azext_confcom/tests/latest/test_confcom_template_util.py
@@ -489,16 +489,17 @@ LmZyYW1ld29yay5lcnJvcnN9Cg=="""
             }
         }
         """
+        filename = "test_template.json"
         # write template to file for testing
-        with open("test_template.json", "w") as f:
+        with open(filename, "w") as f:
             f.write(template)
 
         with self.assertRaises(SystemExit) as exc_info:
-            acipolicygen_confcom(None, "test_template.json", None, None, None, None)
+            acipolicygen_confcom(None, filename, None, None, None, None)
 
         self.assertEqual(exc_info.exception.code, 0)
 
-        with open("test_template.json", "r") as f:
+        with open(filename, "r") as f:
             template_with_policy = load_json_from_str(f.read())
 
             # check if template contains confidential compute policy
@@ -528,4 +529,4 @@ LmZyYW1ld29yay5lcnJvcnN9Cg=="""
                 > 0
             )
         # delete test file
-        os.remove("test_template.json")
+        os.remove(filename)


### PR DESCRIPTION
Open request to make changes to tests so we can fit inside the 60m requirement of the upstream repo.

The main change in this PR is to use smaller images and reduce file I/O by sharing written files across tests and cleaning them up after the test class finishes.