### PR TITLE
using smaller images for tests

### DIFF
--- a/src/confcom/azext_confcom/template_util.py
+++ b/src/confcom/azext_confcom/template_util.py
@@ -29,6 +29,9 @@ class DockerClient:
     def __init__(self) -> None:
         self._client = None
 
+    def __enter__(self) -> docker.DockerClient:
+        return self.get_client()
+
     def get_client(self) -> docker.DockerClient:
         if not self._client:
             self._client = docker.from_env()

--- a/src/confcom/azext_confcom/tests/latest/README.md
+++ b/src/confcom/azext_confcom/tests/latest/README.md
@@ -31,17 +31,17 @@ test_arm_template_with_parameter_file | mcr.microsoft.com/azure-functions/python
 test_arm_template_with_parameter_file_injected_env_vars | mcr.microsoft.com/azure-functions/python:4-python3.8 | See if env vars from the image are injected into the policy. Also make sure the `concat` function in ARM template won't break the CLI if it's not in a required spot like image name
 test_arm_template_with_parameter_file_arm_config | mcr.microsoft.com/azure-functions/python:4-python3.8 | Test valid case of using a parameter file with JSON output instead of Rego
 test_arm_template_with_parameter_file_clean_room | mcr.microsoft.com/azure-functions/node:4 | Test clean room case where image specified does not exist remotely but does locally
-test_policy_diff | rust:1.52.1 | See if the diff functionality outputs `True` when diffs match completely
-test_incorrect_policy_diff | rust:1.52.1 | Check output formatting and functionality of diff command
+test_policy_diff | alpine:3.16 | See if the diff functionality outputs `True` when diffs match completely
+test_incorrect_policy_diff | alpine:3.16 | Check output formatting and functionality of diff command
 test_update_infrastructure_svn | python:3.6.14-slim-buster | Change the minimum SVN for the insfrastructure fragment
-test_multiple_policies | python:3.6.14-slim-buster & rust:1.52.1 | See if two unique policies are generated from a single ARM Template container multiple container groups. Also have an extra resource that is untouched. Also has a secureValue for an environment variable.
-test_arm_template_with_init_container | python:3.6.14-slim-buster & rust:1.52.1 | See if having an initContainer is picked up and added to the list of valid containers
-test_arm_template_without_stdio_access | rust:1.52.1 | See if disabling container stdio access gets passed down to individual containers
-test_arm_template_allow_elevated_false | rust:1.52.1 | Disabling allow_elevated via securityContext
+test_multiple_policies | python:3.6.14-slim-buster & alpine:3.16 | See if two unique policies are generated from a single ARM Template container multiple container groups. Also have an extra resource that is untouched. Also has a secureValue for an environment variable.
+test_arm_template_with_init_container | python:3.6.14-slim-buster & alpine:3.16 | See if having an initContainer is picked up and added to the list of valid containers
+test_arm_template_without_stdio_access | alpine:3.16 | See if disabling container stdio access gets passed down to individual containers
+test_arm_template_allow_elevated_false | alpine:3.16 | Disabling allow_elevated via securityContext
 test_arm_template_policy_regex | python:3.6.14-slim-buster | Make sure the regex generated from the ARM Template workflow matches that of the policy.json workflow
 test_wildcard_env_var | python:3.6.14-slim-buster | Check that an "allow all" regex is created when a value for env var is not provided via a parameter value
 test_wildcard_env_var_invalid | N/A | Make sure the process errors out if a value is not given for an env var or an undefined parameter is used for the name of an env var
-test_arm_template_with_env_var | rust:1.52.1 | Make sure that a value that looks similar to but is not an ARM parameter is treated as a string
+test_arm_template_with_env_var | alpine:3.16 | Make sure that a value that looks similar to but is not an ARM parameter is treated as a string
 test_arm_template_security_context_defaults | N/A | Make sure default values for securityContext are correct
 test_arm_template_security_context_allow_privilege_escalation | N/A | See if changing the allowPrivilegeEscalation flag is working
 test_arm_template_security_context_user | N/A | Set the user field manually to make sure it is reflected in the policy
@@ -64,7 +64,7 @@ It is still used for generating sidecar CCE Policies.
 
 Test Name | Image Used | Purpose
 ---|---|---
-test_user_container_customized_mounts | rust:1.52.1 | See if mounts are translated correctly to the appropriate source and destination locations
+test_user_container_customized_mounts | alpine:3.16 | See if mounts are translated correctly to the appropriate source and destination locations
 test_user_container_mount_injected_dns | python:3.6.14-slim-buster | See if the resolvconf mount works properly
 test_injected_sidecar_container_msi | mcr.microsoft.com/aci/msi-atlas-adapter:master_20201203.1 | Make sure User mounts and env vars aren't added to sidecar containers, using JSON output format
 test_debug_flags | python:3.6.14-slim-buster | Enable flags set via debug_mode
@@ -74,17 +74,17 @@ test_incorrect_sidecar | mcr.microsoft.com/aci/msi-atlas-adapter:master_20201210
 test_customized_workingdir | python:3.6.14-slim-buster | Using different working dir than specified in image metadata
 test_allow_elevated | python:3.6.14-slim-buster | Using allow_elevated in container
 test_image_layers_python | python:3.6.14-slim-buster | Make sure image layers are as expected
-test_image_layers_rust | rust:1.52.1 | Make sure image layers are as expected with different image
-test_docker_pull | rust:1.52.1 | Test pulling an image from docker client
-test_infrastructure_svn | rust:1.52.1 | make sure the correct infrastructure_svn is present in the policy
+test_image_layers_nginx | nginx:1.22 | Make sure image layers are as expected with different image
+test_docker_pull | alpine:3.16 | Test pulling an image from docker client
+test_infrastructure_svn | alpine:3.16 | make sure the correct infrastructure_svn is present in the policy
 test_stdio_access_default | python:3.6.14-slim-buster | Checking the default value for std I/O access
 test_stdio_access_updated | python:3.6.14-slim-buster | Checking the value for std I/O when it's set
 test_environment_variables_parsing | mcr.microsoft.com/azuredocs/aci-dataprocessing-cc:v1 | Make sure env vars are output in the right format
 test_get_layers_from_not_exists_image | notexists:1.0.0 | Fail out grabbing layers if image doesn't exist
-test_incorrect_allow_elevated_data_type | rust:1.52.1 | Making allow_elevated fail out if it's not a boolean
-test_incorrect_workingdir_path | rust:1.52.1 | Fail if working dir isn't an absolute path string
-test_incorrect_workingdir_data_type | rust:1.52.1 | Fail if working dir is an array
-test_incorrect_command_data_type | rust:1.52.1 | Fail if command is not array of strings
+test_incorrect_allow_elevated_data_type | alpine:3.16 | Making allow_elevated fail out if it's not a boolean
+test_incorrect_workingdir_path | alpine:3.16 | Fail if working dir isn't an absolute path string
+test_incorrect_workingdir_data_type | alpine:3.16 | Fail if working dir is an array
+test_incorrect_command_data_type | alpine:3.16 | Fail if command is not array of strings
 test_json_missing_containers | N/A | Fail if containers are not specified
 test_json_missing_version | mcr.microsoft.com/azuredocs/aci-dataprocessing-cc:v1 | Fail if version is not included in policy.json
 test_json_missing_containerImage | N/A | Fail if container doesn't have an image specified

--- a/src/confcom/azext_confcom/tests/latest/test_confcom_image.py
+++ b/src/confcom/azext_confcom/tests/latest/test_confcom_image.py
@@ -5,7 +5,6 @@
 
 import os
 import unittest
-import pytest
 import json
 import deepdiff
 import docker
@@ -19,9 +18,6 @@ import azext_confcom.config as config
 
 TEST_DIR = os.path.abspath(os.path.join(os.path.abspath(__file__), ".."))
 
-
-# @unittest.skip("not in use")
-@pytest.mark.run(order=1)
 class PolicyGeneratingImage(unittest.TestCase):
     custom_json = """
         {
@@ -53,9 +49,6 @@ class PolicyGeneratingImage(unittest.TestCase):
         # deep diff the output policies from the regular policy.json and the single image
         self.assertEqual(self.aci_policy.get_serialized_output(), self.custom_policy.get_serialized_output())
 
-
-# @unittest.skip("not in use")
-@pytest.mark.run(order=2)
 class PolicyGeneratingImageSidecar(unittest.TestCase):
     custom_json = """
         {
@@ -89,9 +82,6 @@ class PolicyGeneratingImageSidecar(unittest.TestCase):
     def test_sidecar_image_policy(self):
         self.assertEqual(self.aci_policy.get_serialized_output(), self.custom_policy.get_serialized_output())
 
-
-# @unittest.skip("not in use")
-@pytest.mark.run(order=3)
 class PolicyGeneratingImageInvalid(unittest.TestCase):
     def test_invalid_image_policy(self):
 
@@ -102,9 +92,6 @@ class PolicyGeneratingImageInvalid(unittest.TestCase):
             policy.populate_policy_content_for_all_images(individual_image=True)
         self.assertEqual(exc_info.exception.code, 1)
 
-
-# @unittest.skip("not in use")
-@pytest.mark.run(order=4)
 class PolicyGeneratingImageCleanRoom(unittest.TestCase):
     def test_clean_room_policy(self):
         client = docker.from_env()

--- a/src/confcom/azext_confcom/tests/latest/test_confcom_scenario.py
+++ b/src/confcom/azext_confcom/tests/latest/test_confcom_scenario.py
@@ -5,7 +5,6 @@
 
 import os
 import unittest
-import pytest
 import json
 
 from azext_confcom.security_policy import (
@@ -19,9 +18,6 @@ from azext_confcom.template_util import case_insensitive_dict_get
 
 TEST_DIR = os.path.abspath(os.path.join(os.path.abspath(__file__), ".."))
 
-
-# @unittest.skip("not in use")
-@pytest.mark.run(order=1)
 class MountEnforcement(unittest.TestCase):
     custom_json = """
     {
@@ -150,9 +146,6 @@ class MountEnforcement(unittest.TestCase):
             mount[config.POLICY_FIELD_CONTAINERS_ELEMENTS_MOUNTS_OPTIONS][2], "rw"
         )
 
-
-# @unittest.skip("not in use")
-@pytest.mark.run(order=2)
 class PolicyGenerating(unittest.TestCase):
     custom_json = """
       {
@@ -364,9 +357,6 @@ class PolicyGenerating(unittest.TestCase):
         self.assertEqual(image._workingDir, expected_workingdir)
 
 
-
-# @unittest.skip("not in use")
-@pytest.mark.run(order=12)
 class PolicyGeneratingDebugMode(unittest.TestCase):
     custom_json = """
       {
@@ -413,9 +403,6 @@ class PolicyGeneratingDebugMode(unittest.TestCase):
         self.assertTrue(expected_capability_dropping in policy)
         self.assertTrue(expected_unencrypted_scratch in policy)
 
-
-# @unittest.skip("not in use")
-@pytest.mark.run(order=11)
 class SidecarValidation(unittest.TestCase):
     custom_json = """
       {
@@ -509,9 +496,6 @@ class SidecarValidation(unittest.TestCase):
 
         self.assertEqual(diff, expected_diff)
 
-
-# @unittest.skip("not in use")
-@pytest.mark.run(order=4)
 class CustomJsonParsing(unittest.TestCase):
     def test_customized_workingdir(self):
         custom_json = """
@@ -599,13 +583,13 @@ class CustomJsonParsing(unittest.TestCase):
             for i in range(len(expected_layers)):
                 self.assertEqual(layers[i], expected_layers[i])
 
-    def test_image_layers_rust(self):
+    def test_image_layers_nginx(self):
         custom_json = """
         {
             "version": "1.0",
             "containers": [
                 {
-                    "containerImage": "rust:1.52.1",
+                    "containerImage": "nginx:1.22",
                     "environmentVariables": [],
                     "command": ["echo", "hello"]
                 }
@@ -619,12 +603,12 @@ class CustomJsonParsing(unittest.TestCase):
             layers = aci_policy.get_images()[0]._layers
 
             expected_layers = [
-                "fe84c9d5bfddd07a2624d00333cf13c1a9c941f3a261f13ead44fc6a93bc0e7a",
-                "4dedae42847c704da891a28c25d32201a1ae440bce2aecccfa8e6f03b97a6a6c",
-                "41d64cdeb347bf236b4c13b7403b633ff11f1cf94dbc7cf881a44d6da88c5156",
-                "eb36921e1f82af46dfe248ef8f1b3afb6a5230a64181d960d10237a08cd73c79",
-                "e769d7487cc314d3ee748a4440805317c19262c7acd2fdbdb0d47d2e4613a15c",
-                "1b80f120dbd88e4355d6241b519c3e25290215c469516b49dece9cf07175a766",
+                "5250e7d2517bcae4d264c84d8e7c6da14607ce867e29a81bf4327ee6896218a3",
+                "b6d54ad6a7223dd687d308c8562aaa7dfef2f5a88ec701fb3f89e49312832b82",
+                "8608c5be3af25ed58b2291999fe76cc021ced0ea70b6387c4373c6551f4d6ddb",
+                "1e0878890d701c494c8aeade31d15eaaf9b9c382c27e2519727cb5d1e91df764",
+                "233b6e2f8931a4d67930ac602688acc16c930926fcadc9e31195440db0737791",
+                "1053a7714644b99537bc0e8058a7e4771d2fe679ef54097e128a813f3c80a9cf",
             ]
             self.assertEqual(len(layers), len(expected_layers))
             for i in range(len(expected_layers)):
@@ -636,7 +620,7 @@ class CustomJsonParsing(unittest.TestCase):
             "version": "1.0",
             "containers": [
                 {
-                    "containerImage": "rust:1.52.1",
+                    "containerImage": "alpine:3.16",
                     "environmentVariables": [],
                     "command": ["echo", "hello"]
                 }
@@ -645,10 +629,12 @@ class CustomJsonParsing(unittest.TestCase):
         """
         with load_policy_from_str(custom_json) as aci_policy:
             image = aci_policy.pull_image(aci_policy.get_images()[0])
-            self.assertIsNotNone(image)
+            self.assertIsNotNone(image.id)
+            print("image: ", image)
+
             self.assertEqual(
                 image.id,
-                "sha256:83ac22b6cf50c51a1d11b3220316be73271e59d30a65f33f4391dc4cfabdc856",
+                "sha256:187eae39ad949e24d9410fa5c4eab8cafba7edd4892211c1d710bdaf49265c37",
             )
 
     def test_infrastructure_svn(self):
@@ -657,7 +643,7 @@ class CustomJsonParsing(unittest.TestCase):
             "version": "1.0",
             "containers": [
                 {
-                    "containerImage": "rust:1.52.1",
+                    "containerImage": "alpine:3.16",
                     "environmentVariables": [],
                     "command": ["echo", "hello"]
                 }
@@ -781,9 +767,6 @@ class CustomJsonParsing(unittest.TestCase):
         )
 
 
-
-# @unittest.skip("not in use")
-@pytest.mark.run(order=5)
 class CustomJsonParsingIncorrect(unittest.TestCase):
     def test_get_layers_from_not_exists_image(self):
         # if an image does not exists in local container repo/daemon, an
@@ -811,7 +794,7 @@ class CustomJsonParsingIncorrect(unittest.TestCase):
             "version": "1.0",
             "containers": [
                 {
-                    "containerImage": "rust:1.52.1",
+                    "containerImage": "alpine:3.16",
                     "environmentVariables": [],
                     "command": "echo hello",
                     "workingDir": "relative/string/path",
@@ -831,7 +814,7 @@ class CustomJsonParsingIncorrect(unittest.TestCase):
             "version": "1.0",
             "containers": [
                 {
-                    "containerImage": "rust:1.52.1",
+                    "containerImage": "alpine:3.16",
                     "environmentVariables": [],
                     "command": "echo hello",
                     "workingDir": "relative/string/path"
@@ -850,7 +833,7 @@ class CustomJsonParsingIncorrect(unittest.TestCase):
             "version": "1.0",
             "containers": [
                 {
-                    "containerImage": "rust:1.52.1",
+                    "containerImage": "alpine:3.16",
                     "environmentVariables": [],
                     "command": "echo hello",
                     "workingDir": ["hello"]
@@ -869,7 +852,7 @@ class CustomJsonParsingIncorrect(unittest.TestCase):
             "version": "1.0",
             "containers": [
                 {
-                    "containerImage": "rust:1.52.1",
+                    "containerImage": "alpine:3.16",
                     "environmentVariables": [],
                     "command": "echo hello"
                 }

--- a/src/confcom/azext_confcom/tests/latest/test_confcom_startup.py
+++ b/src/confcom/azext_confcom/tests/latest/test_confcom_startup.py
@@ -4,65 +4,42 @@
 # --------------------------------------------------------------------------------------------
 
 import os
-import unittest
-import pytest
-
+from azure.cli.testsdk import ScenarioTest
 from azext_confcom.custom import acipolicygen_confcom
-
-import pytest
 
 TEST_DIR = os.path.abspath(os.path.join(os.path.abspath(__file__), ".."))
 
-
-# @unittest.skip("not in use")
-@pytest.mark.run(order=1)
-class InitialErrors(unittest.TestCase):
+class InitialErrors(ScenarioTest):
     def test_invalid_output_flags(self):
         with self.assertRaises(SystemExit) as wrapped_exit:
-            acipolicygen_confcom(
-                "fakepath/input.json",
-                None,
-                None,
-                None,
-                None,
-                None,
-                outraw=True,
-                outraw_pretty_print=True,
-            )
+            self.cmd("az confcom acipolicygen -i fakepath/input.json --outraw --outraw-pretty-print")
         self.assertEqual(wrapped_exit.exception.code, 1)
 
         with self.assertRaises(SystemExit) as wrapped_exit:
-            acipolicygen_confcom(
-                "fakepath/input.json", None, None, None, None, None, outraw=True, print_policy_to_terminal=True
-            )
+            self.cmd("az confcom acipolicygen -i fakepath/input.json --outraw --print-policy")
         self.assertEqual(wrapped_exit.exception.code, 1)
 
         with self.assertRaises(SystemExit) as wrapped_exit:
-            acipolicygen_confcom(
-                "fakepath/input.json", None, None, None, None, None, print_policy_to_terminal=True, outraw_pretty_print=True
-            )
+            self.cmd("az confcom acipolicygen -i fakepath/input.json --print-policy --outraw-pretty-print")
         self.assertEqual(wrapped_exit.exception.code, 1)
 
     def test_invalid_many_input_types(self):
         with self.assertRaises(SystemExit) as wrapped_exit:
-            acipolicygen_confcom(
-                "fakepath/input.json", "fakepath2/template.json", None, None, None, None
-            )
+            self.cmd("az confcom acipolicygen -i fakepath/input.json -a fakepath2/template.json")
         self.assertEqual(wrapped_exit.exception.code, 1)
 
     def test_diff_wrong_input_type(self):
         with self.assertRaises(SystemExit) as wrapped_exit:
-            acipolicygen_confcom(
-                "fakepath/input.json", None, None, None, None, None, diff=True
-            )
+            self.cmd("az confcom acipolicygen -i fakepath/input.json --diff")
         self.assertEqual(wrapped_exit.exception.code, 1)
 
         with self.assertRaises(SystemExit) as wrapped_exit:
-            acipolicygen_confcom(None, None, None, "alpine", None, None, diff=True)
+            self.cmd("az confcom acipolicygen --image alpine --diff")
         self.assertEqual(wrapped_exit.exception.code, 1)
 
     def test_parameters_without_template(self):
         with self.assertRaises(SystemExit) as wrapped_exit:
+            self.cmd("az confcom acipolicygen -p fakepath/parameters.json")
             acipolicygen_confcom(
                 None, None, "fakepath/parameters.json", None, None, None
             )

--- a/src/confcom/azext_confcom/tests/latest/test_confcom_template_util.py
+++ b/src/confcom/azext_confcom/tests/latest/test_confcom_template_util.py
@@ -5,7 +5,6 @@
 
 import os
 import unittest
-import pytest
 from azext_confcom.custom import acipolicygen_confcom
 import azext_confcom.config as config
 from azext_confcom.template_util import (
@@ -13,13 +12,9 @@ from azext_confcom.template_util import (
     extract_confidential_properties,
 )
 from azext_confcom.os_util import load_json_from_str
-import pytest
 
 TEST_DIR = os.path.abspath(os.path.join(os.path.abspath(__file__), ".."))
 
-
-# @unittest.skip("not in use")
-@pytest.mark.run(order=1)
 class TemplateUtil(unittest.TestCase):
     def test_case_insensitive_dict_get(self):
         test_dict = {"key1": "value1", "key2": "value2", "KEY3": "value3"}


### PR DESCRIPTION
some of the tests were using images that were >1GB so dmverity hashing the layers took a long time. This is replacing some of those images for smaller ones so the tests will run faster