### PR TITLE
Updated docker dependency

### DIFF
--- a/src/confcom/setup.py
+++ b/src/confcom/setup.py
@@ -36,7 +36,7 @@ CLASSIFIERS = [
 ]
 
 DEPENDENCIES = [
-    "docker==6.0.1",
+    "docker>=6.1.0",
     "tqdm==4.65.0",
     "deepdiff==6.3.0"
 ]


### PR DESCRIPTION
Updated the docker SDK (`docker`) dependency to >= 6.1.0. Previous dependency was set to = 6.0.1. 
6.1.0 had a bugfix to support `requests` 2.29.0+ and `urllib3` 2.x. `confcom` needs these libraries to instantiate a docker client, and users who have updated versions of `requests` or `urllib3` would get an error when using `confcom`. 