### PR TITLE
adding more tests for katapolicygen

### DIFF
--- a/src/confcom/azext_confcom/tests/latest/test_confcom_kata.py
+++ b/src/confcom/azext_confcom/tests/latest/test_confcom_kata.py
@@ -45,7 +45,7 @@ spec:
                 "fakepath/input.json",
                 None,
             )
-        self.assertNotEqual(wrapped_exit.exception.code, 0)
+        self.assertEqual(wrapped_exit.exception.code, 101)
 
     def test_invalid_config_map_path(self):
         filename = "pod.yaml"
@@ -56,7 +56,29 @@ spec:
                 filename, "fakepath/configmap.yaml",
             )
         os.remove(filename)
-        self.assertNotEqual(wrapped_exit.exception.code, 0)
+        self.assertEqual(wrapped_exit.exception.code, 101)
+
+    def test_valid_cached(self):
+        filename = "pod3.yaml"
+        with open(filename, "w") as f:
+            f.write(KataPolicyGen.pod_string)
+        with self.assertRaises(SystemExit) as wrapped_exit:
+            katapolicygen_confcom(
+                filename, None, use_cached_files=True
+            )
+        os.remove(filename)
+        self.assertEqual(wrapped_exit.exception.code, 0)
+
+    def test_valid(self):
+        filename = "pod4.yaml"
+        with open(filename, "w") as f:
+            f.write(KataPolicyGen.pod_string)
+        with self.assertRaises(SystemExit) as wrapped_exit:
+            katapolicygen_confcom(
+                filename, None
+            )
+        os.remove(filename)
+        self.assertEqual(wrapped_exit.exception.code, 0)
 
     def test_invalid_settings(self):
         filename = "pod2.yaml"


### PR DESCRIPTION
Previously, genpolicy did not allow for concurrent running. Now it does so we can test functionality more accurately.
