### PR TITLE
adding new way to read from tar files

### DIFF
--- a/src/confcom/azext_confcom/security_policy.py
+++ b/src/confcom/azext_confcom/security_policy.py
@@ -412,7 +412,7 @@ class AciPolicy:  # pylint: disable=too-many-instance-attributes
                         image.set_command(command)
 
                     # merge envs for user container image
-                    envs = image_info.get("Env")
+                    envs = image_info.get("Env") or []
                     env_names = [
                         env_var[
                             config.POLICY_FIELD_CONTAINERS_ELEMENTS_ENVS_RULE

--- a/src/confcom/azext_confcom/template_util.py
+++ b/src/confcom/azext_confcom/template_util.py
@@ -81,9 +81,14 @@ def get_image_info(progress, message_queue, tar_mapping, image):
         if tar_location:
             with tarfile.open(tar_location) as tar:
                 # get all the info out of the tarfile
-                image_info = os_util.map_image_from_tar(
-                    image_name, tar, tar_location
-                )
+                try:
+                    image_info = os_util.map_image_from_tar_backwards_compatibility(
+                        image_name, tar, tar_location
+                    )
+                except IndexError:
+                    image_info = os_util.map_image_from_tar(
+                        image_name, tar, tar_location
+                    )
                 if image_info is not None:
                     tar = True
                     message_queue.append(f"{image_name} read from local tar file")

--- a/src/confcom/azext_confcom/tests/latest/test_confcom_scenario.py
+++ b/src/confcom/azext_confcom/tests/latest/test_confcom_scenario.py
@@ -635,7 +635,7 @@ class CustomJsonParsing(unittest.TestCase):
 
             self.assertEqual(
                 image.id,
-                "sha256:e525c930fe751104ff24c356a7bcfad66ce4b92797780eb38dc2ff95d7a66fdc",
+                "sha256:d49a5025be10344cce77d178103a225cb5d7316861e5d8f106e7ff278ae51b62",
             )
 
     def test_infrastructure_svn(self):


### PR DESCRIPTION
Docker changed the internal structure of their saved tar files, so this is adding compatibility for the new version while keeping the old one as it is. This will depend on what version of docker the customer has installed when they generate the tar files.

Also a bugfix for empty Env in the image manifest, and the hash of one of our test images changed.