### PR TITLE
adding faster hashing option

### DIFF
--- a/src/confcom/HISTORY.rst
+++ b/src/confcom/HISTORY.rst
@@ -2,6 +2,10 @@
 
 Release History
 ===============
+0.3.4
+++++++
+* adding faster hashing flag to use buffered reader in dmverity-vhd
+
 0.3.3
 ++++++
 * improving testing standards from pytest recommendations

--- a/src/confcom/azext_confcom/_help.py
+++ b/src/confcom/azext_confcom/_help.py
@@ -81,6 +81,10 @@ helps[
           type: boolean
           short-summary: 'When enabled, the generated security policy is printed to the command line instead of injected into the input ARM Template'
 
+        - name: --faster-hashing
+          type: boolean
+          short-summary: 'When enabled, the hashing algorithm used to generate the policy is faster but less memory efficient'
+
     examples:
         - name: Input an ARM Template file to inject a base64 encoded Confidential Container Security Policy into the ARM Template
           text: az confcom acipolicygen --template-file "./template.json"

--- a/src/confcom/azext_confcom/_params.py
+++ b/src/confcom/azext_confcom/_params.py
@@ -121,6 +121,12 @@ def load_arguments(self, _):
             required=False,
             help="Print the generated policy in the terminal",
         )
+        c.argument(
+            "faster_hashing",
+            options_list=("--faster-hashing"),
+            required=False,
+            help="Use buffered image reader for dmverity hashing. This will speed up the hashing process but use much more memory.",
+        )
 
     with self.argument_context("confcom katapolicygen") as c:
         c.argument(

--- a/src/confcom/azext_confcom/custom.py
+++ b/src/confcom/azext_confcom/custom.py
@@ -43,6 +43,7 @@ def acipolicygen_confcom(
     print_policy_to_terminal: bool = False,
     disable_stdio: bool = False,
     print_existing_policy: bool = False,
+    faster_hashing: bool = False,
 ):
 
     if sum(map(bool, [input_path, arm_template, image_name])) != 1:
@@ -57,6 +58,8 @@ def acipolicygen_confcom(
         )
     elif save_to_file and arm_template and not (print_policy_to_terminal or outraw or outraw_pretty_print):
         error_out("Must print policy to terminal when saving to file")
+    elif faster_hashing and tar_mapping_location:
+        error_out("Cannot use --faster-hashing with --tar")
 
     if print_existing_policy or outraw or outraw_pretty_print:
         logger.warning(
@@ -124,7 +127,7 @@ def acipolicygen_confcom(
 
     for count, policy in enumerate(container_group_policies):
         policy.populate_policy_content_for_all_images(
-            individual_image=bool(image_name), tar_mapping=tar_mapping
+            individual_image=bool(image_name), tar_mapping=tar_mapping, faster_hashing=faster_hashing
         )
 
         if validate_sidecar:

--- a/src/confcom/azext_confcom/data/internal_config.json
+++ b/src/confcom/azext_confcom/data/internal_config.json
@@ -1,5 +1,5 @@
 {
-    "version": "0.3.3",
+    "version": "0.3.4",
     "hcsshim_config": {
         "maxVersion": "1.0.0",
         "minVersion": "0.0.1"

--- a/src/confcom/azext_confcom/rootfs_proxy.py
+++ b/src/confcom/azext_confcom/rootfs_proxy.py
@@ -88,7 +88,11 @@ class SecurityPolicyProxy:  # pylint: disable=too-few-public-methods
             os.chmod(self.policy_bin, st.st_mode | stat.S_IXUSR)
 
     def get_policy_image_layers(
-        self, image: str, tag: str, tar_location: str = ""
+        self,
+        image: str,
+        tag: str,
+        tar_location: str = "",
+        faster_hashing=False
     ) -> List[str]:
         image_name = f"{image}:{tag}"
         # populate layer info
@@ -106,6 +110,9 @@ class SecurityPolicyProxy:  # pylint: disable=too-few-public-methods
             arg_list += ["--tarball", tar_location]
         else:
             arg_list += ["-d"]
+
+        if not tar_location and faster_hashing:
+            arg_list += ["-b"]
 
         # add the image to the end of the parameter list
         arg_list += ["roothash", "-i", f"{image_name}"]

--- a/src/confcom/azext_confcom/security_policy.py
+++ b/src/confcom/azext_confcom/security_policy.py
@@ -352,7 +352,7 @@ class AciPolicy:  # pylint: disable=too-many-instance-attributes
 
     # pylint: disable=R0914, R0915
     def populate_policy_content_for_all_images(
-        self, individual_image=False, tar_mapping=None
+        self, individual_image=False, tar_mapping=None, faster_hashing=False,
     ) -> None:
         # suppress warning which will break the progress bar
         warnings.filterwarnings(
@@ -471,7 +471,7 @@ class AciPolicy:  # pylint: disable=too-many-instance-attributes
                     tar_location = get_tar_location_from_mapping(tar_mapping, image_name)
                 # populate layer info
                 image.set_layers(proxy.get_policy_image_layers(
-                    image.base, image.tag, tar_location=tar_location if tar else ""
+                    image.base, image.tag, tar_location=tar_location if tar else "", faster_hashing=faster_hashing
                 ))
 
                 progress.update()

--- a/src/confcom/azext_confcom/tests/latest/test_confcom_arm.py
+++ b/src/confcom/azext_confcom/tests/latest/test_confcom_arm.py
@@ -1976,8 +1976,8 @@ class MultiplePolicyTemplate(unittest.TestCase):
         temp_policies = load_policy_from_arm_template_str(cls.custom_json, "")
         cls.aci_policy = temp_policies[0]
         cls.aci_policy2 = temp_policies[1]
-        cls.aci_policy.populate_policy_content_for_all_images()
-        cls.aci_policy2.populate_policy_content_for_all_images()
+        cls.aci_policy.populate_policy_content_for_all_images(faster_hashing=True)
+        cls.aci_policy2.populate_policy_content_for_all_images(faster_hashing=True)
 
     def test_multiple_policies(self):
         container_start = "containers := "

--- a/src/confcom/setup.py
+++ b/src/confcom/setup.py
@@ -18,7 +18,7 @@ except ImportError:
 
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
 
-VERSION = "0.3.3"
+VERSION = "0.3.4"
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
This takes advantage of the new flag in [dmverity-vhd](https://github.com/microsoft/hcsshim/pull/2013) that loads the image into memory to allow for faster hashing, but less memory efficiency.