### PR TITLE
changing what tag name to look for in genpolicy release

### DIFF
--- a/src/confcom/azext_confcom/kata_proxy.py
+++ b/src/confcom/azext_confcom/kata_proxy.py
@@ -41,7 +41,7 @@ class KataPolicyGenProxy:  # pylint: disable=too-few-public-methods
         needed_assets = ["genpolicy", "genpolicy.exe"]
         # search for genpolicy in the assets from kata-container releases
         for release in r.json():
-            if release.get("tag_name").startswith("genpolicy"):
+            if "genpolicy" in release.get("tag_name"):
                 # these should be newest to oldest
                 for asset in release["assets"]:
                     # download the file if it contains genpolicy


### PR DESCRIPTION
The naming format of the genpolicy releases changed from [genpolicy-0.6.2-4](https://github.com/microsoft/kata-containers/releases/tag/genpolicy-0.6.2-4) as an example to [3.2.0.azl0.genpolicy0](https://github.com/microsoft/kata-containers/releases/tag/3.2.0.azl0.genpolicy)

This change picks up both types instead of just the first.