### PR TITLE
fixing bug when trying to do regex via parameters

### DIFF
--- a/src/confcom/azext_confcom/template_util.py
+++ b/src/confcom/azext_confcom/template_util.py
@@ -423,7 +423,7 @@ def replace_params_and_vars(params: dict, vars_dict: dict, attribute):
     if isinstance(attribute, (int, float, bool)):
         out = attribute
     elif isinstance(attribute, str):
-        out = find_value_in_params_and_vars(params, vars_dict, attribute)
+        out = find_value_in_params_and_vars(params, vars_dict, attribute, ignore_undefined_parameters=True)
         param_name = re.finditer(WHOLE_PARAMETER_AND_VARIABLE, attribute)
 
         # there should only be one match


### PR DESCRIPTION
Currently errors out when trying to do regex via leaving out a default value in the arm template and putting in the value to be used in a parameters file. This should fix that, and all unit tests still pass.

TBD why this used to work but doesn't anymore.