### PR TITLE
changing input args for genpolicy

### DIFF
--- a/src/confcom/HISTORY.rst
+++ b/src/confcom/HISTORY.rst
@@ -2,6 +2,13 @@
 
 Release History
 ===============
+0.3.6
+++++++
+* updating genpolicy version up through 3.2.0.azl1.genpolicy0. Please note that this is a breaking change for deploying older policies. With the new node image, 0.3.6 or newer will be required.
+* changing genpolicy flags to give full path to config files instead of path as a flag
+* adding genpolicy flags for --containerd-pull, --containerd-socket-path, --rules-file-name, and --print-version
+* `-c` flag for katapolicygen now supports persistent volume claims
+
 0.3.5
 ++++++
 * making diff mode more robust

--- a/src/confcom/azext_confcom/_help.py
+++ b/src/confcom/azext_confcom/_help.py
@@ -127,6 +127,23 @@ helps[
           type: bool
           short-summary: 'Path to custom settings file'
 
+        - name: --rules-file-name -p
+          type: bool
+          short-summary: 'Path to custom rules file'
+
+        - name: --print-version -v
+          type: bool
+          short-summary: 'Print the version of genpolicy tooling'
+
+        - name: --containerd-pull -d
+          type: string
+          short-summary: 'Use containerd to pull the image. This option is only supported on Linux'
+
+        - name: --containerd-socket-path
+          type: string
+          short-summary: 'Path to the containerd socket. This option is only supported on Linux'
+
+
     examples:
         - name: Input a Kubernetes YAML file to inject a base64 encoded Confidential Container Security Policy into the YAML file
           text: az confcom katapolicygen --yaml "./pod.json"
@@ -136,4 +153,8 @@ helps[
           text: az confcom katapolicygen --yaml "./pod.json" -j "./settings.json"
         - name: Input a Kubernetes YAML file and external config map file
           text: az confcom katapolicygen --yaml "./pod.json" --config-map-file "./configmap.json"
+        - name: Input a Kubernetes YAML file and custom rules file
+          text: az confcom katapolicygen --yaml "./pod.json" -p "./rules.rego"
+        - name: Input a Kubernetes YAML file with a custom containerd socket path
+          text: az confcom katapolicygen --yaml "./pod.json" --containerd-pull --containerd-socket-path "/my/custom/containerd.sock"
 """

--- a/src/confcom/azext_confcom/_params.py
+++ b/src/confcom/azext_confcom/_params.py
@@ -132,7 +132,7 @@ def load_arguments(self, _):
         c.argument(
             "yaml_path",
             options_list=("--yaml", "-y"),
-            required=True,
+            required=False,
             help="Input YAML config file",
         )
         c.argument(
@@ -164,4 +164,28 @@ def load_arguments(self, _):
             options_list=("--settings-file-name", "-j"),
             required=False,
             help="Path for custom settings file",
+        )
+        c.argument(
+            "rules_file_name",
+            options_list=("--rules-file-name", "-p"),
+            required=False,
+            help="Path for custom rules file",
+        )
+        c.argument(
+            "print_version",
+            options_list=("--print-version", "-v"),
+            required=False,
+            help="Print the version of the genpolicy tool",
+        )
+        c.argument(
+            "containerd_pull",
+            options_list=("--containerd-pull", "-d"),
+            required=False,
+            help="Use containerd to pull the image",
+        )
+        c.argument(
+            "containerd_socket_path",
+            options_list=("--containerd-socket-path"),
+            required=False,
+            help="Path to containerd socket if not using the default",
         )

--- a/src/confcom/azext_confcom/custom.py
+++ b/src/confcom/azext_confcom/custom.py
@@ -8,7 +8,7 @@ import sys
 
 from pkg_resources import parse_version
 from knack.log import get_logger
-from azext_confcom.config import DEFAULT_REGO_FRAGMENTS, DATA_FOLDER
+from azext_confcom.config import DEFAULT_REGO_FRAGMENTS
 from azext_confcom import os_util
 from azext_confcom.template_util import (
     pretty_print_func,
@@ -164,14 +164,15 @@ def katapolicygen_confcom(
     print_policy: bool = False,
     use_cached_files: bool = False,
     settings_file_name: str = None,
+    rules_file_name: str = None,
+    print_version: bool = False,
+    containerd_pull: str = False,
+    containerd_socket_path: str = None,
 ):
-
-    if settings_file_name:
-        if "genpolicy-settings.json" in settings_file_name:
-            error_out("Cannot use default settings file names")
-        os_util.copy_file(settings_file_name, DATA_FOLDER)
-
     kata_proxy = KataPolicyGenProxy()
+
+    if not (yaml_path or print_version):
+        error_out("Either --yaml-path or --print-version is required")
 
     output = kata_proxy.kata_genpolicy(
         yaml_path,
@@ -180,6 +181,10 @@ def katapolicygen_confcom(
         print_policy=print_policy,
         use_cached_files=use_cached_files,
         settings_file_name=settings_file_name,
+        rules_file_name=rules_file_name,
+        print_version=print_version,
+        containerd_pull=containerd_pull,
+        containerd_socket_path=containerd_socket_path,
     )
     print(output)
     sys.exit(0)

--- a/src/confcom/azext_confcom/data/internal_config.json
+++ b/src/confcom/azext_confcom/data/internal_config.json
@@ -1,5 +1,5 @@
 {
-    "version": "0.3.5",
+    "version": "0.3.6",
     "hcsshim_config": {
         "maxVersion": "1.0.0",
         "minVersion": "0.0.1"

--- a/src/confcom/azext_confcom/kata_proxy.py
+++ b/src/confcom/azext_confcom/kata_proxy.py
@@ -109,10 +109,18 @@ class KataPolicyGenProxy:  # pylint: disable=too-few-public-methods
         print_policy=False,
         use_cached_files=False,
         settings_file_name=None,
+        rules_file_name=None,
+        print_version=False,
+        containerd_pull=False,
+        containerd_socket_path=None
     ) -> List[str]:
         policy_bin_str = str(self.policy_bin)
         # get path to data and rules folder
-        arg_list = [policy_bin_str, "-y", yaml_path, "-i", DATA_FOLDER]
+        arg_list = [policy_bin_str]
+
+        if yaml_path:
+            arg_list.append("-y")
+            arg_list.append(yaml_path)
 
         if config_map_file is not None:
             arg_list.append("-c")
@@ -127,16 +135,31 @@ class KataPolicyGenProxy:  # pylint: disable=too-few-public-methods
         if use_cached_files:
             arg_list.append("-u")
 
+        arg_list.append("-j")
         if settings_file_name:
-            arg_list.append("-j")
-            # only take the last part of the path for the settings file
-            settings_file_name = os.path.basename(settings_file_name)
             arg_list.append(settings_file_name)
+        else:
+            arg_list.append(os.path.join(DATA_FOLDER, "genpolicy-settings.json"))
+
+        arg_list.append("-p")
+        if rules_file_name:
+            arg_list.append(rules_file_name)
+        else:
+            arg_list.append(os.path.join(DATA_FOLDER, "rules.rego"))
+
+        if print_version:
+            arg_list.append("-v")
+
+        if containerd_pull:
+            item_to_append = "-d"
+            # -d by itself will use default path: /var/run/containerd/containerd.sock
+            # -d=my/path/my_containerd.sock will use the specified path
+            if containerd_socket_path:
+                item_to_append += f"={containerd_socket_path}"
+            arg_list.append(item_to_append)
 
         item = subprocess.run(
             arg_list,
-            # stdout=sys.stdout,
-            # stderr=sys.stderr,
             check=False,
         )
 

--- a/src/confcom/setup.py
+++ b/src/confcom/setup.py
@@ -18,7 +18,7 @@ except ImportError:
 
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
 
-VERSION = "0.3.5"
+VERSION = "0.3.6"
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
Upcoming change to genpolicy splits the `-i` flag into two separate flags so the paths to the `rules.rego` and `genpolicy-settings.json` are decoupled. This allows for that and makes it so custom settings files don't need to be copied to the same folder as `rules.rego`