### PR TITLE
making vn2 use a config file

### DIFF
--- a/src/confcom/azext_confcom/_params.py
+++ b/src/confcom/azext_confcom/_params.py
@@ -134,79 +134,13 @@ def load_arguments(self, _):
             required=False,
             help="Path to the virtual kubelet yaml file",
         )
+        c.argument(
+            "podspec_config",
+            options_list=("--podspec-config", "-c"),
+            required=False,
+            help="Path to the podspec config file",
+        )
 
-        c.argument(
-            "configmaps",
-            options_list=("--configmaps"),
-            required=False,
-            help="Kubernetes config map filename",
-        )
-        c.argument(
-            "kubernetes_port",
-            options_list=("--kubernetes-port"),
-            required=False,
-            help="KUBERNETES_PORT environment variable (default 'tcp://10.0.0.1:443')",
-        )
-        c.argument(
-            "kubernetes_port_tcp",
-            options_list=("--kubernetes-port-tcp"),
-            required=False,
-            help="KUBERNETES_PORT_443_TCP environment variable (default 'tcp://10.0.0.1:443')",
-        )
-        c.argument(
-            "kubernetes_port_tcp_addr",
-            options_list=("--kubernetes-port-tcp-addr"),
-            required=False,
-            help="KUBERNETES_PORT_443_TCP_ADDRESS environment variable (default '10.0.0.1')",
-        )
-        c.argument(
-            "kubernetes_port_tcp_proto",
-            options_list=("--kubernetes-port-tcp-proto"),
-            required=False,
-            help="KUBERNETES_PORT_443_TCP_PROTO environment variable (default 'tcp')",
-        )
-        c.argument(
-            "kubernetes_service_host",
-            options_list=("--kubernetes-service-host"),
-            required=False,
-            help="KUBERNETES_SERVICE_HOST environment variable (default '10.0.0.1')",
-        )
-        c.argument(
-            "kubernetes_service_port",
-            options_list=("--kubernetes-service-port"),
-            required=False,
-            help="KUBERNETES_SERVICE_PORT environment variable (default '443')",
-        )
-        c.argument(
-            "kubernetes_service_port_https",
-            options_list=("--kubernetes-service-port-https"),
-            required=False,
-            help="KUBERNETES_SERVICE_PORT_HTTPS environment variable (default '443')",
-        )
-        c.argument(
-            "kubernetes_tcp_port",
-            options_list=("--kubernetes-tcp-port"),
-            required=False,
-            help="KUBERNETES_PORT_443_TCP_PORT environment variable (default '443')",
-        )
-        c.argument(
-            "output_file_name",
-            options_list=("--output-file-name"),
-            required=False,
-            help="Name of the output file (default 'arm-template.json')",
-        )
-        c.argument(
-            "print_json",
-            options_list=("--print-json"),
-            required=False,
-            help="Whether or not to print ARM template",
-        )
-        c.argument(
-            "secrets",
-            options_list=("--secrets"),
-            required=False,
-            help="Kubernetes secrets filename",
-        )
 
     with self.argument_context("confcom katapolicygen") as c:
         c.argument(

--- a/src/confcom/azext_confcom/template_util.py
+++ b/src/confcom/azext_confcom/template_util.py
@@ -55,6 +55,7 @@ def case_insensitive_dict_get(dictionary, search_key) -> Any:
             return dictionary[key]
     return None
 
+
 def deep_dict_update(source: dict, destination: dict):
     """
     https://stackoverflow.com/questions/20656135/python-deep-merge-dictionary-data
@@ -62,6 +63,9 @@ def deep_dict_update(source: dict, destination: dict):
     for key, value in source.items():
         if isinstance(value, dict):
             node = destination.setdefault(key, {})
+            if node is None:
+                destination[key] = {}
+                node = destination[key]
             deep_dict_update(value, node)
         else:
             destination[key] = value

--- a/src/confcom/azext_confcom/virtual_kubelet_proxy.py
+++ b/src/confcom/azext_confcom/virtual_kubelet_proxy.py
@@ -104,7 +104,6 @@ class VirtualKubeletProxy:  # pylint: disable=too-few-public-methods
         kubernetes_service_port_https: str = "",
         kubernetes_tcp_port: str = "",
         output_file_name: str = "arm-template.json",
-        print_json: str = "",
         secrets: str = "",
     ) -> None:
         VirtualKubeletProxy.arm_template_path = output_file_name
@@ -142,8 +141,6 @@ class VirtualKubeletProxy:  # pylint: disable=too-few-public-methods
             arg_list += ["--kubernetes-tcp-port", f"{kubernetes_tcp_port}"]
         if output_file_name:
             arg_list += ["--output-file-name", f"{output_file_name}"]
-        if print_json:
-            arg_list += ["--print-json", f"{print_json}"]
         if secrets:
             arg_list += ["--secrets", f"{secrets}"]
 

--- a/src/confcom/samples/kubelet_config.json
+++ b/src/confcom/samples/kubelet_config.json
@@ -1,0 +1,13 @@
+{
+    "configmaps": "<configmap-file>.yaml",
+    "kubernetes_port": "",
+    "kubernetes_port_tcp": "",
+    "kubernetes_port_tcp_addr": "",
+    "kubernetes_port_tcp_proto": "",
+    "kubernetes_service_host": "",
+    "kubernetes_service_port": "",
+    "kubernetes_service_port_https": "",
+    "kubernetes_tcp_port": "",
+    "output_file_name": "arm-template.json",
+    "secrets": "<secrets-file>.yaml"
+}

--- a/src/confcom/setup.py
+++ b/src/confcom/setup.py
@@ -18,7 +18,7 @@ except ImportError:
 
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
 
-VERSION = "0.4.0"
+VERSION = "0.4.2-alpha"
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
Currently there are lots of configuration arguments to be used for VN2. This improves the user experience by being able to check in configuration with git to give more reproducible operations.