### PR TITLE
Prompt to confirm policy overwrite for VN2 YAML

### DIFF
--- a/src/confcom/azext_confcom/tests/latest/test_confcom_arm.py
+++ b/src/confcom/azext_confcom/tests/latest/test_confcom_arm.py
@@ -1359,7 +1359,7 @@ class PolicyGeneratingArmParametersCleanRoom(unittest.TestCase):
     }
     """
         with DockerClient() as client:
-            original_image = "mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0"
+            original_image = "mcr.microsoft.com/cbl-mariner/base/nginx:1-cm2.0"
             try:
                 client.images.remove(original_image)
             except:

--- a/src/confcom/azext_confcom/tests/latest/test_confcom_scenario.py
+++ b/src/confcom/azext_confcom/tests/latest/test_confcom_scenario.py
@@ -577,8 +577,8 @@ class CustomJsonParsing(unittest.TestCase):
             aci_policy.populate_policy_content_for_all_images()
             layers = aci_policy.get_images()[0]._layers
             expected_layers = [
-                "bf5cf1c854c39af7769ca161f772c48da37d86cd7e56ba4c18b1e8d97259a089",
-                "4c32767c28c09e3d6ff280d2b6f2b4d92e90f45b2e1728b83edd91cc5da41066"
+                "e1385118e8a5f9f9751d096e1dbe734c601fa93cd031045c6d70d4bc47479f90",
+                "41ac484628e184e63ef0d4fc4d4cb3133eec849022d24bd737ac8a36bb3a1212"
             ]
             self.assertEqual(len(layers), len(expected_layers))
             for i in range(len(expected_layers)):


### PR DESCRIPTION
This update introduces prompts for the user to confirm if they want to overwrite the base64 policy in each workload within a YAML file (which we already have for ARM templates). Also refactors VN2 policy logic to be closer to what we have for ARM templates. 

So, the workflow is
* Iterate through YAML workloads (separated by ---)
* Serialize them
* Prompt user if they want to overwrite the policy (if a policy is already in the YAML)
* Update the YAML with the new policy if confirmed. 

Ran `azdev style` and `azdev test`.