### PR TITLE
adding --omit-id to acifragmentgen

### DIFF
--- a/src/confcom/HISTORY.rst
+++ b/src/confcom/HISTORY.rst
@@ -9,6 +9,7 @@ Release History
 * bug fixes for image-attached fragments
 * adding ability to generate a fragment import from an image name using the remote attached fragments
 * updating stdout import statement to look more like the file output
+* adding `--omit-id` to the `acifragmentgen` command
 
 1.1.1
 ++++++

--- a/src/confcom/azext_confcom/_help.py
+++ b/src/confcom/azext_confcom/_help.py
@@ -91,7 +91,7 @@ helps[
 
         - name: --omit-id
           type: boolean
-          short-summary: 'When enabled, the generated policy will not contain the ID field. This will keep the policy from being tied to a specific image name and tag'
+          short-summary: 'When enabled, the generated policy will not contain the ID field. This will keep the policy from being tied to a specific image name and tag. This is helpful if the image being used will be present in multiple registries and used interchangeably'
 
         - name: --include-fragments -f
           type: boolean
@@ -166,6 +166,10 @@ helps[
         - name: --fragment-path -p
           type: string
           short-summary: 'Path to an existing policy fragment file to be used with --generate-import. This option allows you to create import statements for the specified fragment without needing to pull it from an OCI registry'
+
+        - name: --omit-id
+          type: boolean
+          short-summary: 'When enabled, the generated policy will not contain the ID field. This will keep the policy from being tied to a specific image name and tag. This is helpful if the image being used will be present in multiple registries and used interchangeably'
 
         - name: --generate-import -g
           type: boolean

--- a/src/confcom/azext_confcom/_params.py
+++ b/src/confcom/azext_confcom/_params.py
@@ -268,6 +268,12 @@ def load_arguments(self, _):
             validator=validate_fragment_path,
         )
         c.argument(
+            "omit_id",
+            options_list=("--omit-id"),
+            required=False,
+            help="Omit the id field in the policy. This is helpful if the image being used will be present in multiple registries and used interchangeably.",
+        )
+        c.argument(
             "generate_import",
             options_list=("--generate-import", "-g"),
             required=False,

--- a/src/confcom/azext_confcom/custom.py
+++ b/src/confcom/azext_confcom/custom.py
@@ -225,6 +225,7 @@ def acifragmentgen_confcom(
     image_target: str = "",
     algo: str = "ES384",
     fragment_path: str = None,
+    omit_id: bool = False,
     generate_import: bool = False,
     disable_stdio: bool = False,
     debug_mode: bool = False,
@@ -306,7 +307,7 @@ def acifragmentgen_confcom(
         # strip the tag or hash off the image name so there are stable feed names
         feed = get_image_name(image_target)
 
-    fragment_text = policy.generate_fragment(namespace, svn, output_type)
+    fragment_text = policy.generate_fragment(namespace, svn, output_type, omit_id=omit_id)
 
     if output_type != security_policy.OutputType.DEFAULT and not no_print:
         print(fragment_text)

--- a/src/confcom/azext_confcom/data/internal_config.json
+++ b/src/confcom/azext_confcom/data/internal_config.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.1.2-alpha.2",
+    "version": "1.1.2-alpha.5",
     "hcsshim_config": {
         "maxVersion": "1.0.0",
         "minVersion": "0.0.1"

--- a/src/confcom/azext_confcom/security_policy.py
+++ b/src/confcom/azext_confcom/security_policy.py
@@ -181,12 +181,12 @@ class AciPolicy:  # pylint: disable=too-many-instance-attributes
         # encode to base64
         return os_util.str_to_base64(policy_str)
 
-    def generate_fragment(self, namespace: str, svn: str, output_type: int) -> str:
+    def generate_fragment(self, namespace: str, svn: str, output_type: int, omit_id: bool = False) -> str:
         return config.CUSTOMER_REGO_FRAGMENT % (
             namespace,
             pretty_print_func(svn),
             pretty_print_func(self.get_fragments()),
-            self.get_serialized_output(output_type, rego_boilerplate=False, include_sidecars=False),
+            self.get_serialized_output(output_type, rego_boilerplate=False, include_sidecars=False, omit_id=omit_id),
         )
 
     def _add_rego_boilerplate(self, output: str) -> str:
@@ -388,7 +388,7 @@ class AciPolicy:  # pylint: disable=too-many-instance-attributes
         for image in regular_container_images:
             image_dict = image.get_policy_json(omit_id=omit_id)
             policy.append(image_dict)
-        if not is_sidecars and include_sidecars:
+        if (not is_sidecars or len(regular_container_images) == 0) and include_sidecars:
             # add in the default containers that have their hashes pre-computed
             policy += copy.deepcopy(config.DEFAULT_CONTAINERS)
             if self._disable_stdio:

--- a/src/confcom/azext_confcom/tests/latest/README.md
+++ b/src/confcom/azext_confcom/tests/latest/README.md
@@ -158,6 +158,7 @@ Test Name | Image Used | Purpose
 ---|---|---
 test_fragment_user_container_customized_mounts | mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0 | See if mounts are translated correctly to the appropriate source and destination locations
 test_fragment_user_container_mount_injected_dns | mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0 | See if the resolvconf mount works properly
+test_fragment_omit_id | mcr.microsoft.com/aci/msi-atlas-adapter:master_20201203.1 | Check that the id field is omitted from the policy
 test_fragment_injected_sidecar_container_msi | mcr.microsoft.com/aci/msi-atlas-adapter:master_20201203.1 | Make sure User mounts and env vars aren't added to sidecar containers, using JSON output format
 test_debug_processes | mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0 | Enable exec_processes via debug_mode
 test_fragment_sidecar | mcr.microsoft.com/aci/msi-atlas-adapter:master_20201210.1 | See if sidecar fragments can be created by a given policy.json

--- a/src/confcom/azext_confcom/tests/latest/test_confcom_fragment.py
+++ b/src/confcom/azext_confcom/tests/latest/test_confcom_fragment.py
@@ -27,6 +27,7 @@ from azext_confcom.os_util import (
     write_str_to_file,
     load_json_from_file,
     load_str_from_file,
+    load_json_from_str,
     delete_silently,
 )
 from azext_confcom.custom import acifragmentgen_confcom
@@ -277,6 +278,24 @@ class FragmentGenerating(unittest.TestCase):
         with load_policy_from_config_str(cls.custom_json) as aci_policy:
             aci_policy.populate_policy_content_for_all_images()
             cls.aci_policy = aci_policy
+
+
+    def test_fragment_omit_id(self):
+        output = self.aci_policy.get_serialized_output(
+            output_type=OutputType.RAW, rego_boilerplate=False, omit_id=True
+        )
+        output_json = load_json_from_str(output)
+
+        self.assertNotIn("id", output_json[0])
+
+        # test again with omit_id=False
+        output2 = self.aci_policy.get_serialized_output(
+            output_type=OutputType.RAW, rego_boilerplate=False
+        )
+        output_json2 = load_json_from_str(output2)
+
+        self.assertIn("id", output_json2[0])
+
 
     def test_fragment_injected_sidecar_container_msi(self):
         image = self.aci_policy.get_images()[0]

--- a/src/confcom/setup.py
+++ b/src/confcom/setup.py
@@ -19,7 +19,7 @@ except ImportError:
 
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
 
-VERSION = "1.1.2-alpha.2"
+VERSION = "1.1.2-alpha.5"
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
This was a missing feature in fragments that is present in `acipolicygen` to make it so images that live in multiple repositories can have the same policy hash. Also making it so empty policies still have the pause container.