### PR TITLE
Add aciconvert subcommand to confcom

### DIFF
--- a/src/confcom/HISTORY.rst
+++ b/src/confcom/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+1.2.1
+++++++
+* updating genpolicy to version 3.2.0.azl3.genpolicy3
+
 1.2.0
 ++++++
 * fixing metadata for uploaded fragments

--- a/src/confcom/azext_confcom/_help.py
+++ b/src/confcom/azext_confcom/_help.py
@@ -220,7 +220,7 @@ helps[
     "confcom aciconvert"
 ] = """
     type: command
-    short-summary: Convert either a VN2 yaml file or an ARM Template to a raw JSON input file to then be used with acipolicygen.
+    short-summary: Convert a Virtual Node YAML file or an ARM Template into a raw JSON file for use with acipolicygen.
 
     parameters:
         - name: --template-file -a
@@ -247,6 +247,13 @@ helps[
           type: boolean
           short-summary: 'Output JSON in pretty print format'
 
+    examples:
+        - name: Convert an ARM Template file to a JSON file.
+          text: az confcom aciconvert --template-file "./template.json" --output-filename "./output.json"
+        - name: Convert a Virtual Node YAML file to a pretty-printed JSON file.
+          text: az confcom aciconvert --virtual-node-yaml "./pod.yaml" --outraw-pretty-print --output-filename "./output.json"
+        - name: Convert an ARM Template file with a parameters file.
+          text: az confcom aciconvert --template-file "./template.json" --parameters "./parameters.json" --output-filename "./output.json"
 """
 
 helps[

--- a/src/confcom/azext_confcom/_help.py
+++ b/src/confcom/azext_confcom/_help.py
@@ -217,6 +217,39 @@ helps[
 """
 
 helps[
+    "confcom aciconvert"
+] = """
+    type: command
+    short-summary: Convert either a VN2 yaml file or an ARM Template to a raw JSON input file to then be used with acipolicygen.
+
+    parameters:
+        - name: --template-file -a
+          type: string
+          short-summary: 'Input ARM Template file'
+
+        - name: --parameters -p
+          type: string
+          short-summary: 'Input parameters file to optionally accompany an ARM Template'
+
+        - name: --virtual-node-yaml
+          type: string
+          short-summary: 'Input YAML file for Virtual Node policy generation'
+
+        - name: --image
+          type: string
+          short-summary: 'Input image name'
+
+        - name: --output-filename
+          type: string
+          short-summary: 'Save output JSON to given file path'
+
+        - name: --outraw-pretty-print
+          type: boolean
+          short-summary: 'Output JSON in pretty print format'
+
+"""
+
+helps[
     "confcom katapolicygen"
 ] = """
     type: command

--- a/src/confcom/azext_confcom/_params.py
+++ b/src/confcom/azext_confcom/_params.py
@@ -24,6 +24,7 @@ from azext_confcom._validators import (
     validate_fragment_json_policy,
     validate_image_target,
     validate_upload_fragment,
+    validate_aci_convert_source
 )
 
 

--- a/src/confcom/azext_confcom/_params.py
+++ b/src/confcom/azext_confcom/_params.py
@@ -332,6 +332,49 @@ def load_arguments(self, _):
             validator=validate_fragment_json,
         )
 
+    with self.argument_context("confcom aciconvert") as c:
+        c.argument(
+            "arm_template",
+            options_list=("--template-file", "-a"),
+            required=False,
+            help="ARM template file",
+            validator=validate_aci_convert_source
+        )
+        c.argument(
+            "arm_template_parameters",
+            options_list=("--parameters", "-p"),
+            required=False,
+            help="ARM template parameters",
+            validator=validate_params_file
+        )
+        c.argument(
+            "virtual_node_yaml_path",
+            options_list=("--virtual-node-yaml"),
+            required=False,
+            help="Virtual node YAML file",
+            validator=validate_aci_convert_source
+        )
+        c.argument(
+            "image_name",
+            options_list=("--image",),
+            required=False,
+            help="Image Name",
+            validator=validate_aci_convert_source
+        )
+        c.argument(
+            "output_filename",
+            options_list=("--output-filename"),
+            required=False,
+            help="Output filename for the generated JSON",
+        )
+        c.argument(
+            "outraw_pretty_print",
+            options_list=("--outraw-pretty-print"),
+            required=False,
+            action="store_true",
+            help="Output policy in clear text and pretty print format",
+        )
+
     with self.argument_context("confcom katapolicygen") as c:
         c.argument(
             "yaml_path",

--- a/src/confcom/azext_confcom/_validators.py
+++ b/src/confcom/azext_confcom/_validators.py
@@ -40,7 +40,12 @@ def validate_aci_convert_source(namespace):
         namespace.arm_template,
         namespace.virtual_node_yaml_path
     ])) != 1:
-        raise CLIError("Must provide an ARM template or VN2 YAML file to convert to JSON")
+        raise CLIError(
+            "Invalid input: Please provide exactly one of the following options to convert to JSON:\n"
+            "- An ARM template file (use --template-file)\n"
+            "- A Virtual Node YAML file (use --virtual-node-yaml)\n"
+            "- An image name (use --image)"
+        )
 
 
 def validate_faster_hashing(namespace):

--- a/src/confcom/azext_confcom/_validators.py
+++ b/src/confcom/azext_confcom/_validators.py
@@ -34,6 +34,15 @@ def validate_aci_source(namespace):
         raise CLIError("Can only generate CCE policy from one source at a time")
 
 
+def validate_aci_convert_source(namespace):
+    if sum(map(bool, [
+        namespace.image_name,
+        namespace.arm_template,
+        namespace.virtual_node_yaml_path
+    ])) != 1:
+        raise CLIError("Must provide an ARM template or VN2 YAML file to convert to JSON")
+
+
 def validate_faster_hashing(namespace):
     if namespace.faster_hashing and namespace.tar_mapping_location:
         raise CLIError("Cannot use --faster-hashing with --tar")

--- a/src/confcom/azext_confcom/commands.py
+++ b/src/confcom/azext_confcom/commands.py
@@ -10,6 +10,7 @@ def load_command_table(self, _):
         g.custom_command("acipolicygen", "acipolicygen_confcom")
         g.custom_command("acifragmentgen", "acifragmentgen_confcom")
         g.custom_command("katapolicygen", "katapolicygen_confcom")
+        g.custom_command("aciconvert", "convert_to_json_confcom")
 
     with self.command_group("confcom"):
         pass

--- a/src/confcom/azext_confcom/commands.py
+++ b/src/confcom/azext_confcom/commands.py
@@ -10,7 +10,7 @@ def load_command_table(self, _):
         g.custom_command("acipolicygen", "acipolicygen_confcom")
         g.custom_command("acifragmentgen", "acifragmentgen_confcom")
         g.custom_command("katapolicygen", "katapolicygen_confcom")
-        g.custom_command("aciconvert", "convert_to_json_confcom")
+        g.custom_command("aciconvert", "convert_to_json_confcom", is_preview=True)
 
     with self.command_group("confcom"):
         pass

--- a/src/confcom/azext_confcom/container.py
+++ b/src/confcom/azext_confcom/container.py
@@ -602,6 +602,12 @@ class ContainerImage:
     def get_policy_json(self, omit_id: bool = False) -> str:
         return self._populate_policy_json_elements(omit_id=omit_id)
 
+    def get_container_image(self) -> str:
+        return f"{self.base}:{self.tag}"
+
+    def get_exec_processes(self) -> List:
+        return self._exec_processes
+
     def get_id(self) -> str:
         return self._identifier
 

--- a/src/confcom/azext_confcom/custom.py
+++ b/src/confcom/azext_confcom/custom.py
@@ -377,6 +377,10 @@ def convert_to_json_confcom(
             arm_template,
             arm_template_parameters
         )
+        # fill in values for parameters and variables
+        for container_group in container_group_policies:
+            for container in container_group.get_images():
+                container.parse_all_parameters_and_variables(container_group.all_params, container_group.all_vars)
     elif image_name:
         container_group_policies = security_policy.load_policy_from_image_name(image_name)
     elif virtual_node_yaml_path:

--- a/src/confcom/azext_confcom/custom.py
+++ b/src/confcom/azext_confcom/custom.py
@@ -405,7 +405,6 @@ def convert_to_json_confcom(
             print(json_str)
 
 
-
 def update_confcom(cmd, instance, tags=None):
     with cmd.update_context(instance) as c:
         c.set_param("tags", tags)

--- a/src/confcom/azext_confcom/data/internal_config.json
+++ b/src/confcom/azext_confcom/data/internal_config.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.2.0",
+    "version": "1.2.1",
     "hcsshim_config": {
         "maxVersion": "1.0.0",
         "minVersion": "0.0.1"

--- a/src/confcom/azext_confcom/security_policy.py
+++ b/src/confcom/azext_confcom/security_policy.py
@@ -416,8 +416,8 @@ class AciPolicy:  # pylint: disable=too-many-instance-attributes
             properties["image"] = image.get_container_image()
             if image.get_command():
                 properties["command"] = image.get_command()
-            if image.get_environment_rules():
-                env_rules = image.get_environment_rules()
+            if image._get_environment_rules():
+                env_rules = image._get_environment_rules()
                 split_env_rules = []
                 for env in env_rules:
                     temp_env = {}

--- a/src/confcom/azext_confcom/security_policy.py
+++ b/src/confcom/azext_confcom/security_policy.py
@@ -400,6 +400,54 @@ class AciPolicy:  # pylint: disable=too-many-instance-attributes
             return pretty_print_func(policy)
         return print_func(policy)
 
+    def output_data_as_json(self, pretty_print=False,) -> str:
+        output_json = {
+            "containers": []
+        }
+        regular_container_images = self.get_images()
+
+        for image in regular_container_images:
+            temp_container = {
+                "properties": {}
+            }
+            properties = temp_container["properties"]
+
+            temp_container["name"] = image.get_name()
+            properties["image"] = image.get_container_image()
+            if image.get_command():
+                properties["command"] = image.get_command()
+            if image.get_environment_rules():
+                env_rules = image.get_environment_rules()
+                split_env_rules = []
+                for env in env_rules:
+                    temp_env = {}
+                    rule = temp_env["name"] = env[config.POLICY_FIELD_CONTAINERS_ELEMENTS_ENVS_RULE]
+                    if rule.count("=") != 1:
+                        logger.warning("Environment variable rule %s has more than one '='. Please verify its format in the output file", rule)
+                    temp_env["name"] = rule.split("=")[0]
+                    temp_env["value"] = rule.split("=")[1]
+                    temp_env["strategy"] = env[config.POLICY_FIELD_CONTAINERS_ELEMENTS_ENVS_STRATEGY]
+                    temp_env["required"] = env[config.POLICY_FIELD_CONTAINERS_ELEMENTS_REQUIRED]
+                    split_env_rules.append(temp_env)
+                properties["environmentVariables"] = split_env_rules
+            if image.get_working_dir():
+                properties["workingDirectory"] = image.get_working_dir()
+            if image.get_mounts():
+                properties["volumeMounts"] = image.get_mounts()
+            if image.get_exec_processes():
+                properties["execProcesses"] = image.get_exec_processes()
+            # if image.get_signals():
+            #     properties["signals"] = image.get_signals()
+            # if image.get_security_context():
+            #     properties["securityContext"] = image.get_security_context()
+            output_json["containers"].append(temp_container)
+
+        if pretty_print:
+            return pretty_print_func(output_json)
+        return print_func(output_json)
+
+
+
     # pylint: disable=R0914, R0915
     def populate_policy_content_for_all_images(
         self, individual_image=False, tar_mapping=None, faster_hashing=False,

--- a/src/confcom/azext_confcom/security_policy.py
+++ b/src/confcom/azext_confcom/security_policy.py
@@ -531,6 +531,7 @@ class AciPolicy:  # pylint: disable=too-many-instance-attributes
                                     config.POLICY_FIELD_CONTAINERS_ELEMENTS_REQUIRED: False,
                                 }
                             )
+                    image.get_environment_rules().sort(key=lambda env: env.get('pattern', ''))
 
                     # merge signals for user container image
                     signals = image_info.get("StopSignal")
@@ -1014,7 +1015,7 @@ def load_policy_from_str(
         container[config.ACI_FIELD_CONTAINERS_SIGNAL_CONTAINER_PROCESSES] = []
 
         if image_properties:
-            exec_processes = []
+            exec_processes = case_insensitive_dict_get(image_properties, config.ACI_FIELD_CONTAINERS_EXEC_PROCESSES) or []
             extract_probe(exec_processes, image_properties, config.ACI_FIELD_CONTAINERS_READINESS_PROBE)
             extract_probe(exec_processes, image_properties, config.ACI_FIELD_CONTAINERS_LIVENESS_PROBE)
             container[config.ACI_FIELD_CONTAINERS_CONTAINERIMAGE] = image_name

--- a/src/confcom/azext_confcom/template_util.py
+++ b/src/confcom/azext_confcom/template_util.py
@@ -497,11 +497,15 @@ def process_env_vars_from_config(container) -> List[Dict[str, str]]:
         elif not value:
             eprint(f'Environment variable {name} does not have a value. Please check the template file.')
 
+        strategy = "re2" if (
+            case_insensitive_dict_get(env_var, "regex") or
+            case_insensitive_dict_get(env_var, config.ACI_FIELD_CONTAINERS_ENVS_STRATEGY) == "re2"
+        ) else "string"
+
         env_vars.append({
             config.ACI_FIELD_CONTAINERS_ENVS_NAME: name,
             config.ACI_FIELD_CONTAINERS_ENVS_VALUE: value,
-            config.ACI_FIELD_CONTAINERS_ENVS_STRATEGY:
-                "re2" if case_insensitive_dict_get(env_var, "regex") else "string",
+            config.ACI_FIELD_CONTAINERS_ENVS_STRATEGY: strategy,
         })
 
     return env_vars

--- a/src/confcom/azext_confcom/tests/latest/test_confcom_aciconvert.py
+++ b/src/confcom/azext_confcom/tests/latest/test_confcom_aciconvert.py
@@ -1,0 +1,396 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+import os
+import unittest
+import json
+from azext_confcom.custom import convert_to_json_confcom
+
+TEST_DIR = os.path.abspath(os.path.join(os.path.abspath(__file__), ".."))
+
+
+class AciconvertTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        # Example ARM template
+        cls.arm_template_content = {
+            "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+            "contentVersion": "1.0.0.0",
+            "parameters": {
+                "containerGroupName": {
+                    "type": "string",
+                    "defaultValue": "my-container-group"
+                },
+                "containerName": {
+                    "type": "string",
+                    "defaultValue": "my-container"
+                }
+            },
+            "variables": {
+                "image": "mcr.microsoft.com/cbl-mariner/distroless/python:3.9-nonroot"
+            },
+            "resources": [
+                {
+                    "type": "Microsoft.ContainerInstance/containerGroups",
+                    "apiVersion": "2023-05-01",
+                    "name": "[parameters('containerGroupName')]",
+                    "location": "[resourceGroup().location]",
+                    "properties": {
+                        "containers": [
+                            {
+                                "name": "[parameters('containerName')]",
+                                "properties": {
+                                    "image": "[variables('image')]",
+                                    "command": [
+                                        "python3"
+                                    ],
+                                    "resources": {
+                                        "requests": {
+                                            "cpu": 1.0,
+                                            "memoryInGb": 1.5
+                                        }
+                                    },
+                                    "volumeMounts": [
+                                        {
+                                            "name": "filesharevolume",
+                                            "mountPath": "/aci/logs",
+                                            "readOnly": False
+                                        }
+                                    ]
+                                }
+                            }
+                        ],
+                        "volumes": [
+                            {
+                                "name": "filesharevolume",
+                                "azureFile": {
+                                    "shareName": "my-share",
+                                    "storageAccountName": "my-storage-acct",
+                                    "storageAccountKey": "<secret>"
+                                }
+                            }
+                        ],
+                        "osType": "Linux",
+                        "restartPolicy": "Always",
+                        "confidentialComputeProperties": {
+                            "IsolationType": "SevSnp"
+                        }
+                    }
+                }
+            ],
+            "outputs": {}
+        }
+        cls.arm_template_file = os.path.join(TEST_DIR, "test_arm_template.json")
+        with open(cls.arm_template_file, "w") as f:
+            json.dump(cls.arm_template_content, f, indent=2)
+
+        cls.arm_template_parameters_content = {
+            "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+            "contentVersion": "1.0.0.0",
+            "parameters": {
+                "containerGroupName": {
+                    "value": "my-parameterized-group"
+                },
+                "containerName": {
+                    "value": "my-parameterized-container"
+                }
+            }
+        }
+        cls.arm_template_parameters_file = os.path.join(TEST_DIR, "test_arm_template.parameters.json")
+        with open(cls.arm_template_parameters_file, "w") as f:
+            json.dump(cls.arm_template_parameters_content, f, indent=2)
+
+
+        # Example YAML file
+        cls.yaml_content = """
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: test-app
+  name: test-pod
+spec:
+  containers:
+    - name: container1
+      image: mcr.microsoft.com/cbl-mariner/distroless/python:3.9-nonroot
+      env:
+        - name: ENV_VAR_1
+          value: value1
+        - name: CONFIG_VAR
+          valueFrom:
+            configMapKeyRef:
+              key: config-key
+              name: test-configmap
+        - name: SECRET_VAR
+          valueFrom:
+            secretKeyRef:
+              key: secret-key
+              name: test-secret
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: CPU_LIMIT
+          valueFrom:
+            resourceFieldRef:
+              containerName: container1
+              resource: limits.cpu
+        - name: MEMORY_REQUEST
+          valueFrom:
+            resourceFieldRef:
+              containerName: container1
+              resource: requests.memory
+      livenessProbe:
+        httpGet:
+          path: /healthz
+          port: 8080
+        initialDelaySeconds: 10
+        periodSeconds: 5
+      readinessProbe:
+        httpGet:
+          path: /readiness
+          port: 8080
+        initialDelaySeconds: 5
+        periodSeconds: 5
+      resources:
+        limits:
+          cpu: 500m
+          memory: 128Mi
+        requests:
+          cpu: 250m
+          memory: 64Mi
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      volumeMounts:
+        - mountPath: /etc/config
+          name: config-volume
+        - mountPath: /etc/secrets
+          name: secret-volume
+          readOnly: true
+        - mountPath: /etc/projected
+          name: projected-volume
+        - mountPath: /data
+          name: pvc-volume
+    - name: container2
+      image: mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0
+      command:
+        - sleep
+        - "3600"
+      volumeMounts:
+        - mountPath: /shared
+          name: shared-volume
+  restartPolicy: Always
+  volumes:
+    - name: config-volume
+      configMap:
+        name: test-configmap
+    - name: secret-volume
+      secret:
+        secretName: test-secret
+    - name: projected-volume
+      projected:
+        sources:
+          - configMap:
+              name: test-configmap
+          - secret:
+              name: test-secret
+    - name: pvc-volume
+      persistentVolumeClaim:
+        claimName: test-pvc
+    - name: shared-volume
+      emptyDir: {}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-configmap
+data:
+  another-key: another-value
+  config-key: config-value
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: test-secret
+  type: Opaque
+data:
+  another-secret: YW5vdGhlci12YWx1ZQ==
+  secret-key: c2VjcmV0LXZhbHVl
+"""
+        cls.yaml_file = os.path.join(TEST_DIR, "test_virtual_node.yaml")
+        with open(cls.yaml_file, "w") as f:
+            f.write(cls.yaml_content)
+
+        # Example output file
+        cls.output_file = os.path.join(TEST_DIR, "output.json")
+
+    @classmethod
+    def tearDownClass(cls):
+        # Clean up test files
+        for fpath in [
+            cls.arm_template_file,
+            cls.arm_template_parameters_file,
+            cls.yaml_file,
+            cls.output_file
+        ]:
+            if os.path.exists(fpath):
+                os.remove(fpath)
+
+    def test_convert_arm_template(self):
+        """Test converting an ARM template to JSON."""
+        convert_to_json_confcom(
+            arm_template=self.arm_template_file,
+            arm_template_parameters=None,
+            image_name=None,
+            virtual_node_yaml_path=None,
+            output_filename=self.output_file,
+            outraw_pretty_print=True
+        )
+        # Validate output
+        self.assertTrue(os.path.exists(self.output_file))
+        with open(self.output_file, "r") as f:
+            data = json.load(f)
+
+        # Instead of looking for 'resources',
+        # now you should check for top-level 'containers'
+        self.assertIn("containers", data, "Output JSON must have a 'containers' key.")
+        self.assertGreater(len(data["containers"]), 0, "Expected at least one container in the policy.")
+
+        container0 = data["containers"][0]
+        self.assertIn("properties", container0)
+        props = container0["properties"]
+
+        # Validate container properties
+        self.assertIn("image", props)
+        self.assertEqual(
+            props["image"],
+            "mcr.microsoft.com/cbl-mariner/distroless/python:3.9-nonroot",
+            "Expected ARM variable 'image' to match the policy output"
+        )
+
+        # Validate volume mounts
+        self.assertIn("volumeMounts", props)
+        mount_paths = [mount["mountPath"] for mount in props["volumeMounts"]]
+        self.assertIn("/aci/logs", mount_paths, "Expected '/aci/logs' as a volume mount path.")
+
+    def test_convert_arm_template_with_params(self):
+        """
+        Test converting an ARM template to JSON with an overridden parameter file.
+        This should change the container name and image from the default values in the template.
+        """
+        convert_to_json_confcom(
+            arm_template=self.arm_template_file,
+            arm_template_parameters=self.arm_template_parameters_file,
+            image_name=None,
+            virtual_node_yaml_path=None,
+            output_filename=self.output_file,
+            outraw_pretty_print=True
+        )
+
+        self.assertTrue(os.path.exists(self.output_file))
+        with open(self.output_file, "r") as f:
+            data = json.load(f)
+
+        # We expect top-level "containers"
+        self.assertIn("containers", data, "Output JSON must have a 'containers' key.")
+        self.assertGreater(len(data["containers"]), 0, "Expected at least one container in the policy.")
+
+        container0 = data["containers"][0]
+        self.assertIn("properties", container0)
+        props = container0["properties"]
+
+        # Check that the parameter file's container name is used
+        self.assertEqual(container0["name"], "my-parameterized-container")
+
+    def test_convert_virtual_node_yaml(self):
+        """Test converting a Virtual Node YAML to JSON."""
+        convert_to_json_confcom(
+            arm_template=None,
+            arm_template_parameters=None,
+            image_name=None,
+            virtual_node_yaml_path=self.yaml_file,
+            output_filename=self.output_file,
+            outraw_pretty_print=True
+        )
+        # Validate output
+        self.assertTrue(os.path.exists(self.output_file))
+        with open(self.output_file, "r") as f:
+            data = json.load(f)
+            self.assertIn("containers", data)
+            self.assertEqual(len(data["containers"]), 2)
+            
+            # Validate first container
+            container1 = data["containers"][0]
+            self.assertEqual(container1["name"], "container1")
+            self.assertEqual(container1["properties"]["image"], "mcr.microsoft.com/cbl-mariner/distroless/python:3.9-nonroot")
+            
+            # Validate environment variables
+            env_vars = {var["name"]: var["value"] for var in container1["properties"]["environmentVariables"]}
+            self.assertEqual(env_vars["ENV_VAR_1"], "value1")
+            self.assertEqual(env_vars["CONFIG_VAR"], "config-value")
+            self.assertEqual(env_vars["SECRET_VAR"], "secret-value")
+            
+            # Validate volume mounts
+            volume_mounts = {mount["mountPath"]: mount for mount in container1["properties"]["volumeMounts"]}
+            self.assertIn("/etc/config", volume_mounts)
+            self.assertTrue(volume_mounts["/etc/config"]["readonly"])
+            
+            # Validate second container
+            container2 = data["containers"][1]
+            self.assertEqual(container2["name"], "container2")
+            self.assertEqual(container2["properties"]["image"], "mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0")
+
+    def test_convert_image_name(self):
+        """Test converting an image name to JSON with proper output validation."""
+        from io import StringIO
+        import sys
+
+        # Redirect stdout
+        old_stdout = sys.stdout
+        sys.stdout = StringIO()
+
+        try:
+            convert_to_json_confcom(
+                arm_template=None,
+                arm_template_parameters=None,
+                image_name="mcr.microsoft.com/cbl-mariner/distroless/python:3.9-nonroot",
+                virtual_node_yaml_path=None,
+                output_filename=None,
+                outraw_pretty_print=False
+            )
+            # Capture the output
+            output = sys.stdout.getvalue()
+            self.assertTrue(len(output) > 0)
+
+            # Parse and validate the JSON output
+            data = json.loads(output)
+            self.assertIn("containers", data)
+            self.assertEqual(len(data["containers"]), 1)
+
+            container = data["containers"][0]
+            self.assertEqual(container["name"], "mcr.microsoft.com/cbl-mariner/distroless/python:3.9-nonroot")
+            self.assertIn("properties", container)
+            self.assertEqual(container["properties"]["image"], "mcr.microsoft.com/cbl-mariner/distroless/python:3.9-nonroot")
+
+            # Validate volume mounts
+            volume_mounts = container["properties"].get("volumeMounts", [])
+            self.assertEqual(len(volume_mounts), 1)
+            mount = volume_mounts[0]
+            self.assertEqual(mount["mountPath"], "/etc/resolv.conf")
+            self.assertEqual(mount["mountType"], "resolvconf")
+            self.assertEqual(mount["name"], "dns_resolve")
+            self.assertFalse(mount["readonly"])
+        finally:
+            # Restore stdout
+            sys.stdout = old_stdout

--- a/src/confcom/azext_confcom/tests/latest/test_confcom_arm.py
+++ b/src/confcom/azext_confcom/tests/latest/test_confcom_arm.py
@@ -3546,27 +3546,27 @@ class PolicyGeneratingArmWildcardEnvs(unittest.TestCase):
             ]
             cls.aci_arm_policy2.populate_policy_content_for_all_images()
 
-    # def test_arm_template_policy_regex(self):
-    #     # deep diff the output policies from the regular policy.json and the ARM template
-    #     normalized_aci_policy = json.loads(
-    #         self.aci_policy.get_serialized_output(output_type=OutputType.RAW, rego_boilerplate=False)
-    #     )
+    def test_arm_template_policy_regex(self):
+        # deep diff the output policies from the regular policy.json and the ARM template
+        normalized_aci_policy = json.loads(
+            self.aci_policy.get_serialized_output(output_type=OutputType.RAW, rego_boilerplate=False)
+        )
 
-    #     normalized_aci_arm_policy = json.loads(
-    #         self.aci_arm_policy.get_serialized_output(
-    #             output_type=OutputType.RAW, rego_boilerplate=False
-    #         )
-    #     )
+        normalized_aci_arm_policy = json.loads(
+            self.aci_arm_policy.get_serialized_output(
+                output_type=OutputType.RAW, rego_boilerplate=False
+            )
+        )
 
-    #     normalized_aci_policy[0].pop(config.POLICY_FIELD_CONTAINERS_ID)
+        normalized_aci_policy[0].pop(config.POLICY_FIELD_CONTAINERS_ID)
 
-    #     normalized_aci_arm_policy[0].pop(config.POLICY_FIELD_CONTAINERS_ID)
-    #     self.assertEqual(
-    #         deepdiff.DeepDiff(
-    #             normalized_aci_policy, normalized_aci_arm_policy, ignore_order=True
-    #         ),
-    #         {},
-    #     )
+        normalized_aci_arm_policy[0].pop(config.POLICY_FIELD_CONTAINERS_ID)
+        self.assertEqual(
+            deepdiff.DeepDiff(
+                normalized_aci_policy, normalized_aci_arm_policy, ignore_order=True
+            ),
+            {},
+        )
 
     def test_wildcard_env_var(self):
         # Load the first policy

--- a/src/confcom/azext_confcom/tests/latest/test_confcom_arm.py
+++ b/src/confcom/azext_confcom/tests/latest/test_confcom_arm.py
@@ -1607,8 +1607,8 @@ class PolicyDiff(unittest.TestCase):
                     "no_new_privileges": [{"tested_value": True, "policy_value": False}]
                 },
                 "env_rules": [
-                    "environment variable with rule 'TEST_REGEXP_ENV=test_regexp_en' does not match strings or regex in policy rules",
                     "environment variable with rule 'ENV_VALUE=input_value' does not match strings or regex in policy rules",
+                    "environment variable with rule 'TEST_REGEXP_ENV=test_regexp_en' does not match strings or regex in policy rules",
                 ],
             }
         }
@@ -3546,64 +3546,75 @@ class PolicyGeneratingArmWildcardEnvs(unittest.TestCase):
             ]
             cls.aci_arm_policy2.populate_policy_content_for_all_images()
 
-    def test_arm_template_policy_regex(self):
-        # deep diff the output policies from the regular policy.json and the ARM template
-        normalized_aci_policy = json.loads(
-            self.aci_policy.get_serialized_output(output_type=OutputType.RAW, rego_boilerplate=False)
-        )
+    # def test_arm_template_policy_regex(self):
+    #     # deep diff the output policies from the regular policy.json and the ARM template
+    #     normalized_aci_policy = json.loads(
+    #         self.aci_policy.get_serialized_output(output_type=OutputType.RAW, rego_boilerplate=False)
+    #     )
 
-        normalized_aci_arm_policy = json.loads(
-            self.aci_arm_policy.get_serialized_output(
-                output_type=OutputType.RAW, rego_boilerplate=False
-            )
-        )
+    #     normalized_aci_arm_policy = json.loads(
+    #         self.aci_arm_policy.get_serialized_output(
+    #             output_type=OutputType.RAW, rego_boilerplate=False
+    #         )
+    #     )
 
-        normalized_aci_policy[0].pop(config.POLICY_FIELD_CONTAINERS_ID)
+    #     normalized_aci_policy[0].pop(config.POLICY_FIELD_CONTAINERS_ID)
 
-        normalized_aci_arm_policy[0].pop(config.POLICY_FIELD_CONTAINERS_ID)
-        self.assertEqual(
-            deepdiff.DeepDiff(
-                normalized_aci_policy, normalized_aci_arm_policy, ignore_order=True
-            ),
-            {},
-        )
+    #     normalized_aci_arm_policy[0].pop(config.POLICY_FIELD_CONTAINERS_ID)
+    #     self.assertEqual(
+    #         deepdiff.DeepDiff(
+    #             normalized_aci_policy, normalized_aci_arm_policy, ignore_order=True
+    #         ),
+    #         {},
+    #     )
 
     def test_wildcard_env_var(self):
+        # Load the first policy
         normalized_aci_arm_policy = json.loads(
             self.aci_arm_policy.get_serialized_output(
                 output_type=OutputType.RAW, rego_boilerplate=False
             )
         )
 
+        # Assert that "TEST_WILDCARD_ENV=.*" exists in the environment rules
+        env_rules = normalized_aci_arm_policy[0][config.POLICY_FIELD_CONTAINERS_ELEMENTS_ENVS]
+        matching_rule = next(
+            (rule for rule in env_rules if rule.get(config.POLICY_FIELD_CONTAINERS_ELEMENTS_ENVS_RULE) == "TEST_WILDCARD_ENV=.*"),
+            None,
+        )
+        self.assertIsNotNone(matching_rule, "TEST_WILDCARD_ENV=.* not found in environment rules.")
+
+        # Validate the strategy of the matching rule is "re2"
         self.assertEqual(
-            normalized_aci_arm_policy[0][config.POLICY_FIELD_CONTAINERS_ELEMENTS_ENVS][1][
-                config.POLICY_FIELD_CONTAINERS_ELEMENTS_ENVS_STRATEGY
-            ],
+            matching_rule[config.POLICY_FIELD_CONTAINERS_ELEMENTS_ENVS_STRATEGY],
             "re2",
+            "Expected strategy 're2' for TEST_WILDCARD_ENV=.*"
         )
 
-        self.assertEqual(
-            normalized_aci_arm_policy[0][config.POLICY_FIELD_CONTAINERS_ELEMENTS_ENVS][1][
-                config.POLICY_FIELD_CONTAINERS_ELEMENTS_ENVS_RULE
-            ],
-            "TEST_WILDCARD_ENV=.*",
-        )
-
+        # Load the second policy
         normalized_aci_arm_policy2 = json.loads(
             self.aci_arm_policy2.get_serialized_output(
                 output_type=OutputType.RAW, rego_boilerplate=False
             )
         )
 
+        # Assert that "WILDCARD2" is not present in the second policy
         self.assertFalse(
-            any([item.get("name") == "WILDCARD2" for item in normalized_aci_arm_policy2[0][config.POLICY_FIELD_CONTAINERS_ELEMENTS_ENVS]])
+            any(item.get("name") == "WILDCARD2" for item in normalized_aci_arm_policy2[0][config.POLICY_FIELD_CONTAINERS_ELEMENTS_ENVS]),
+            "Unexpected WILDCARD2 environment variable found."
         )
 
+        # Assert that "TEST_WILDCARD_ENV=.*" exists in the second policy's environment rules
+        env_rules2 = normalized_aci_arm_policy2[0][config.POLICY_FIELD_CONTAINERS_ELEMENTS_ENVS]
+        matching_rule2 = next(
+            (rule for rule in env_rules2 if rule.get(config.POLICY_FIELD_CONTAINERS_ELEMENTS_ENVS_RULE) == "TEST_WILDCARD_ENV=.*"),
+            None,
+        )
+        self.assertIsNotNone(matching_rule2, "TEST_WILDCARD_ENV=.* not found in second policy's environment rules.")
         self.assertEqual(
-            normalized_aci_arm_policy2[0][config.POLICY_FIELD_CONTAINERS_ELEMENTS_ENVS][1][
-                config.POLICY_FIELD_CONTAINERS_ELEMENTS_ENVS_RULE
-            ],
-            "TEST_WILDCARD_ENV=.*",
+            matching_rule2[config.POLICY_FIELD_CONTAINERS_ELEMENTS_ENVS_STRATEGY],
+            "re2",
+            "Expected strategy 're2' for TEST_WILDCARD_ENV=.* in second policy"
         )
 
     def test_wildcard_env_var_invalid(self):
@@ -3758,17 +3769,34 @@ class PolicyGeneratingEdgeCases(unittest.TestCase):
         cls.aci_arm_policy.populate_policy_content_for_all_images()
 
     def test_arm_template_with_env_var(self):
+        # Deserialize the generated policy JSON
         regular_image_json = json.loads(
             self.aci_arm_policy.get_serialized_output(
                 output_type=OutputType.RAW, rego_boilerplate=False
             )
         )
 
-        env_var = regular_image_json[0][config.POLICY_FIELD_CONTAINERS_ELEMENTS_ENVS][0][config.POLICY_FIELD_CONTAINERS_ELEMENTS_ENVS_RULE]
+        # Search for the specific environment variable rule
+        env_rules = regular_image_json[0][config.POLICY_FIELD_CONTAINERS_ELEMENTS_ENVS]
+        matching_env_var = next(
+            (rule for rule in env_rules if rule.get(config.POLICY_FIELD_CONTAINERS_ELEMENTS_ENVS_RULE) == "PORT=parameters('abc')"),
+            None
+        )
 
-        # see if the remote image and the local one produce the same output
-        self.assertEqual(env_var, "PORT=parameters('abc')")
-        self.assertEqual(regular_image_json[0][config.POLICY_FIELD_CONTAINERS_ID], "mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0")
+        # Assert that the expected environment variable exists
+        self.assertIsNotNone(matching_env_var, "Expected environment variable 'PORT=parameters('abc')' not found.")
+        self.assertEqual(
+            matching_env_var[config.POLICY_FIELD_CONTAINERS_ELEMENTS_ENVS_RULE],
+            "PORT=parameters('abc')",
+            "Environment variable rule mismatch."
+        )
+
+        # Assert the container ID is as expected
+        self.assertEqual(
+            regular_image_json[0][config.POLICY_FIELD_CONTAINERS_ID],
+            "mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0",
+            "Container ID mismatch."
+        )
 
     def test_arm_template_config_map_sidecar(self):
         regular_image_json = json.loads(

--- a/src/confcom/azext_confcom/tests/latest/test_confcom_scenario.py
+++ b/src/confcom/azext_confcom/tests/latest/test_confcom_scenario.py
@@ -577,8 +577,8 @@ class CustomJsonParsing(unittest.TestCase):
             aci_policy.populate_policy_content_for_all_images()
             layers = aci_policy.get_images()[0]._layers
             expected_layers = [
-                "069a26cef9f2cd9c8bdbc38adc786292096e80a3f45d1da99532d8c349e3e852",
-                "07d84d8efe92985be1e67f32429ced5a5053d20c57fcb6c7b36b7395310163a1"
+                "7fdd8009ff6abf7a9d48808a507baecd5b815c8947fc03faa921b68a0ac260e8",
+                "280e8f98eb3a45ba7647d3df812236494188bfedb2c1fafa0ac2fb2f47930c0c"
             ]
             self.assertEqual(len(layers), len(expected_layers))
             for i in range(len(expected_layers)):

--- a/src/confcom/setup.py
+++ b/src/confcom/setup.py
@@ -19,7 +19,7 @@ except ImportError:
 
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
 
-VERSION = "1.2.0"
+VERSION = "1.2.1"
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
Introduces `aciconvert` subcommand, which converts ARM templates, images, or YAML files into JSON format. This was an ask from an internal customer. 

Other changes
* Env vars are now sorted alphabetically in the policy. This was done to make the policy from $$\text{YAML} \overset{\text{aciconvert}}{\to} \text{JSON} \overset{\text{acipolicygen}}{\to} \text{Policy}$$ match the policy from $$\text{YAML} \overset{\text{acipolicygen}}{\to} \text{Policy}$$
* Made a few tests more flexible. They assumed the positions of env vars in the policy, but now we just check for existence in the list of env vars.