### PR TITLE
fixing error that came up when using diff mode with non-default fragm…

### DIFF
--- a/src/confcom/azext_confcom/template_util.py
+++ b/src/confcom/azext_confcom/template_util.py
@@ -785,10 +785,13 @@ def readable_diff(diff_dict) -> Dict[str, Any]:
             # search for the area of the ARM Template with the change i.e. "mounts" or "env_rules"
             for key in diff_dict[category]:
                 key = str(key)
-                key_name = re.search(r"'(.*?)'", key).group(1)
-                human_readable_diff[new_name].setdefault(key_name, []).append(
-                    diff_dict[category][key]
-                )
+
+                key_name_group = re.search(r"'(.*?)'", key)
+                if key_name_group is not None:
+                    key_name = key_name_group.group(1)
+                    human_readable_diff[new_name].setdefault(key_name, []).append(
+                        diff_dict[category][key]
+                    )
 
     return change_key_names(human_readable_diff)
 


### PR DESCRIPTION
`key_name` is possibly `None` so we need a null check beforehand