### PR TITLE
adding support for custom mount options

### DIFF
--- a/src/confcom/azext_confcom/security_policy.py
+++ b/src/confcom/azext_confcom/security_policy.py
@@ -1298,7 +1298,8 @@ def load_policy_from_config_str(config_str, debug_mode: bool = False, disable_st
                     container_properties, config.ACI_FIELD_TEMPLATE_COMMAND
                 )
                 or [],
-                config.ACI_FIELD_CONTAINERS_MOUNTS: process_mounts_from_config(container_properties),
+                config.ACI_FIELD_CONTAINERS_MOUNTS: process_mounts_from_config(container_properties)
+                + process_configmap(container_properties),
                 config.ACI_FIELD_CONTAINERS_EXEC_PROCESSES: exec_processes
                 + config.DEBUG_MODE_SETTINGS.get("execProcesses")
                 if debug_mode

--- a/src/confcom/azext_confcom/template_util.py
+++ b/src/confcom/azext_confcom/template_util.py
@@ -684,6 +684,9 @@ def process_mounts_from_config(image_properties: dict) -> List[Dict[str, str]]:
                 config.ACI_FIELD_CONTAINERS_MOUNTS_READONLY: case_insensitive_dict_get(
                     mount, config.ACI_FIELD_TEMPLATE_MOUNTS_READONLY
                 ),
+                config.POLICY_FIELD_CONTAINERS_ELEMENTS_MOUNTS_OPTIONS: case_insensitive_dict_get(
+                    mount, config.POLICY_FIELD_CONTAINERS_ELEMENTS_MOUNTS_OPTIONS
+                )
             }
         )
     return mounts


### PR DESCRIPTION
This was taken out at some point, adding it back in. Also adding support for configmaps