### PR TITLE
adding support for OCI formatted images

### DIFF
--- a/src/confcom/HISTORY.rst
+++ b/src/confcom/HISTORY.rst
@@ -2,6 +2,14 @@
 
 Release History
 ===============
+1.2.2
+++++++
+* support for pure OCI v1 schema 2 formatted images
+* adding debug logging
+* changing where parameters and variables are filled in for arm templates
+* updating documentation about fragments
+* bugfix for exec processes in fragment generation
+* bugfix for custom mount options in fragment generation
 
 1.2.1
 ++++++

--- a/src/confcom/azext_confcom/README.md
+++ b/src/confcom/azext_confcom/README.md
@@ -194,6 +194,8 @@ Use the following command to generate CCE policy for the image.
 az confcom acipolicygen -a .\sample-template-input.json --tar .\file.tar
 ```
 
+Note that multiple images saved to the tar file is only available using the docker-archive format for tar files. OCI does not support multi-image tar files at this time.
+
 Example 12: If it is necessary to put images in their own tarballs, an external file can be used that maps images to their respective tarball paths. See the following example:
 
 ```bash

--- a/src/confcom/azext_confcom/cose_proxy.py
+++ b/src/confcom/azext_confcom/cose_proxy.py
@@ -129,7 +129,7 @@ class CoseSignToolProxy:  # pylint: disable=too-few-public-methods
 
         if iss:
             arg_list.extend(["-issuer", iss])
-        logger.info(f"Signing the policy fragment: {out_path}")
+        logger.info("Signing the policy fragment: %s", out_path)
         call_cose_sign_tool(arg_list, "Error signing the policy fragment")
         return True
 
@@ -151,7 +151,7 @@ class CoseSignToolProxy:  # pylint: disable=too-few-public-methods
         policy_bin_str = str(self.policy_bin)
 
         arg_list_chain = [policy_bin_str, "check", "--in", fragment_path, "--verbose"]
-        logger.info(f"Extracting import statement from signed fragment: {fragment_path}")
+        logger.info("Extracting import statement from signed fragment: %s", fragment_path)
         item = call_cose_sign_tool(arg_list_chain, "Error getting information from signed fragment file")
 
         stdout = item.stdout.decode("utf-8")
@@ -183,7 +183,7 @@ class CoseSignToolProxy:  # pylint: disable=too-few-public-methods
             eprint(f"The fragment file at {fragment_path} does not exist")
 
         arg_list_chain = [policy_bin_str, "check", "--in", fragment_path, "--verbose"]
-        logger.info(f"Extracting payload from signed fragment: {fragment_path}")
+        logger.info("Extracting payload from signed fragment: %s", fragment_path)
         item = call_cose_sign_tool(arg_list_chain, "Error getting information from signed fragment file")
 
         stdout = item.stdout.decode("utf-8")
@@ -195,7 +195,7 @@ class CoseSignToolProxy:  # pylint: disable=too-few-public-methods
             eprint(f"The fragment file at {fragment_path} does not exist")
 
         arg_list_chain = [policy_bin_str, "check", "--in", fragment_path, "--verbose"]
-        logger.info(f"Extracting feed from signed fragment: {fragment_path}")
+        logger.info("Extracting feed from signed fragment: %s", fragment_path)
         item = call_cose_sign_tool(arg_list_chain, "Error getting information from signed fragment file")
 
         stdout = item.stdout.decode("utf-8")

--- a/src/confcom/azext_confcom/data/internal_config.json
+++ b/src/confcom/azext_confcom/data/internal_config.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.2.1",
+    "version": "1.2.2",
     "hcsshim_config": {
         "maxVersion": "1.0.0",
         "minVersion": "0.0.1"

--- a/src/confcom/azext_confcom/oras_proxy.py
+++ b/src/confcom/azext_confcom/oras_proxy.py
@@ -7,6 +7,7 @@ import subprocess
 import json
 import platform
 import re
+from knack.log import get_logger
 from typing import List
 from azext_confcom.errors import eprint
 from azext_confcom.config import ARTIFACT_TYPE
@@ -15,8 +16,6 @@ from azext_confcom.os_util import delete_silently
 
 host_os = platform.system()
 machine = platform.machine()
-
-from knack.log import get_logger
 
 logger = get_logger(__name__)
 
@@ -43,11 +42,12 @@ def prepend_docker_registry(image_name: str) -> str:
         # If no registry is specified, assume docker.io/library
         if "/" not in name:
             # Add the `library` namespace for official images
-            registry = f"library/"
+            registry = "library/"
         # Add the default `docker.io` registry
-        registry = f"docker.io/" + registry
+        registry = f"docker.io/{registry}"
 
     return f"{registry}{image_name}"
+
 
 def call_oras_cli(args, check=False):
     return subprocess.run(args, check=check, capture_output=True, timeout=120)
@@ -65,7 +65,7 @@ def discover(
     item = call_oras_cli(arg_list, check=False)
     hashes = []
 
-    logger.info(f"Discovering fragments for {image}: {item.stdout.decode('utf-8')}")
+    logger.info("Discovering fragments for %s: %s", image, item.stdout.decode('utf-8'))
     if item.returncode == 0:
         json_output = json.loads(item.stdout.decode("utf-8"))
         manifests = json_output.get("manifests", [])
@@ -91,7 +91,7 @@ def pull(
     if "@sha256:" in image:
         image = image.split("@")[0]
     arg_list = ["oras", "pull", f"{image}@{image_hash}"]
-    logger.info(f"Pulling fragment: {image}@{image_hash}")
+    logger.info("Pulling fragment: %s@%s", image, image_hash)
     item = call_oras_cli(arg_list, check=False)
 
     # get the exit code from the subprocess

--- a/src/confcom/azext_confcom/tests/latest/test_confcom_scenario.py
+++ b/src/confcom/azext_confcom/tests/latest/test_confcom_scenario.py
@@ -577,8 +577,8 @@ class CustomJsonParsing(unittest.TestCase):
             aci_policy.populate_policy_content_for_all_images()
             layers = aci_policy.get_images()[0]._layers
             expected_layers = [
-                "7fdd8009ff6abf7a9d48808a507baecd5b815c8947fc03faa921b68a0ac260e8",
-                "280e8f98eb3a45ba7647d3df812236494188bfedb2c1fafa0ac2fb2f47930c0c"
+                "6ee0f2697647b69975229db7445260a1c9ae5b039f9a52a911e72b6c3302d391",
+                "3ba5dd39bf58f28b7e57a52d10edf1813fe3b1fd1d0ef57573b1b912d6b9d1f6"
             ]
             self.assertEqual(len(layers), len(expected_layers))
             for i in range(len(expected_layers)):

--- a/src/confcom/azext_confcom/tests/latest/test_confcom_tar.py
+++ b/src/confcom/azext_confcom/tests/latest/test_confcom_tar.py
@@ -7,11 +7,15 @@ import os
 import unittest
 import deepdiff
 import json
+import shutil
+import tempfile
+from tarfile import TarFile
 
 from azext_confcom.security_policy import (
     OutputType,
     load_policy_from_arm_template_str,
 )
+from azext_confcom.rootfs_proxy import SecurityPolicyProxy
 from azext_confcom.errors import (
     AccContainerError,
 )
@@ -33,6 +37,190 @@ def remove_tar_file(image_path: str) -> None:
     if os.path.isfile(image_path):
         os.remove(image_path)
 
+
+class PolicyGeneratingArmParametersCleanRoomOCITarFile(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        path = os.path.dirname(__file__)
+        cls.path = path
+
+    def test_oci_tar_file(self):
+        custom_arm_json_default_value = """
+    {
+        "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+        "contentVersion": "1.0.0.0",
+
+
+        "parameters": {
+            "containergroupname": {
+                "type": "string",
+                "metadata": {
+                    "description": "Name for the container group"
+                },
+                "defaultValue":"simple-container-group"
+            },
+            "image": {
+                "type": "string",
+                "metadata": {
+                    "description": "Name for the container group"
+                },
+                "defaultValue":"mcr.microsoft.com/aks/e2e/library-busybox:master.220314.1-linux-amd64"
+            },
+            "containername": {
+                "type": "string",
+                "metadata": {
+                    "description": "Name for the container"
+                },
+                "defaultValue":"simple-container"
+            },
+
+            "port": {
+                "type": "string",
+                "metadata": {
+                    "description": "Port to open on the container and the public IP address."
+                },
+                "defaultValue": "8080"
+            },
+            "cpuCores": {
+                "type": "string",
+                "metadata": {
+                    "description": "The number of CPU cores to allocate to the container."
+                },
+                "defaultValue": "1.0"
+            },
+            "memoryInGb": {
+                "type": "string",
+                "metadata": {
+                    "description": "The amount of memory to allocate to the container in gigabytes."
+                },
+                "defaultValue": "1.5"
+            },
+            "location": {
+                "type": "string",
+                "defaultValue": "[resourceGroup().location]",
+                "metadata": {
+                    "description": "Location for all resources."
+                }
+            }
+        },
+        "resources": [
+            {
+            "name": "[parameters('containergroupname')]",
+            "type": "Microsoft.ContainerInstance/containerGroups",
+            "apiVersion": "2023-05-01",
+            "location": "[parameters('location')]",
+
+            "properties": {
+                "containers": [
+                {
+                    "name": "[parameters('containername')]",
+                    "properties": {
+                    "image": "[parameters('image')]",
+                    "environmentVariables": [
+                        {
+                        "name": "PORT",
+                        "value": "80"
+                        }
+                    ],
+
+                    "ports": [
+                        {
+                        "port": "[parameters('port')]"
+                        }
+                    ],
+                    "command": [
+                        "/bin/bash",
+                        "-c",
+                        "while sleep 5; do cat /mnt/input/access.log; done"
+                    ],
+                    "resources": {
+                        "requests": {
+                        "cpu": "[parameters('cpuCores')]",
+                        "memoryInGb": "[parameters('memoryInGb')]"
+                        }
+                    }
+                    }
+                }
+                ],
+
+                "osType": "Linux",
+                "restartPolicy": "OnFailure",
+                "confidentialComputeProperties": {
+                "IsolationType": "SevSnp"
+                },
+                "ipAddress": {
+                "type": "Public",
+                "ports": [
+                    {
+                    "protocol": "Tcp",
+                    "port": "[parameters( 'port' )]"
+                    }
+                ]
+                }
+            }
+            }
+        ],
+        "outputs": {
+            "containerIPv4Address": {
+            "type": "string",
+            "value": "[reference(resourceId('Microsoft.ContainerInstance/containerGroups/', parameters('containergroupname'))).ipAddress.ip]"
+            }
+        }
+    }
+    """
+
+        regular_image = load_policy_from_arm_template_str(
+            custom_arm_json_default_value, ""
+        )[0]
+
+        regular_image.populate_policy_content_for_all_images()
+        SecurityPolicyProxy.layer_cache = {}
+        clean_room_image = load_policy_from_arm_template_str(
+            custom_arm_json_default_value, ""
+        )[0]
+
+        try:
+            with tempfile.TemporaryDirectory() as folder:
+                filename = os.path.join(folder, "oci.tar")
+
+                tar_mapping_file = {"mcr.microsoft.com/aks/e2e/library-busybox:master.220314.1-linux-amd64": os.path.join(self.path, "oci2.tar")}
+                create_tar_file(filename)
+                with TarFile(f"{folder}/oci.tar", "r") as tar:
+                    tar.extractall(path=folder)
+
+                os.remove(os.path.join(folder, "manifest.json"))
+                os.remove(os.path.join(folder, "oci.tar"))
+
+                with TarFile.open(os.path.join(self.path, "oci2.tar"), mode="w") as out_tar:
+                    out_tar.add(os.path.join(folder, "index.json"), "index.json")
+                    out_tar.add(os.path.join(folder, "blobs"), "blobs", recursive=True)
+
+                clean_room_image.populate_policy_content_for_all_images(
+                    tar_mapping=tar_mapping_file
+                )
+        except Exception as e:
+            print(e)
+            raise AccContainerError("Could not get image from tar file")
+        finally:
+            remove_tar_file(filename)
+            remove_tar_file(os.path.join(self.path, "oci2.tar"))
+
+        regular_image_json = json.loads(
+            regular_image.get_serialized_output(output_type=OutputType.RAW, rego_boilerplate=False)
+        )
+
+        clean_room_json = json.loads(
+            clean_room_image.get_serialized_output(output_type=OutputType.RAW, rego_boilerplate=False)
+        )
+
+        regular_image_json[0].pop(config.POLICY_FIELD_CONTAINERS_ID)
+        clean_room_json[0].pop(config.POLICY_FIELD_CONTAINERS_ID)
+
+        # see if the remote image and the local one produce the same output
+        self.assertEqual(
+            deepdiff.DeepDiff(regular_image_json, clean_room_json, ignore_order=True),
+            {},
+        )
 
 class PolicyGeneratingArmParametersCleanRoomTarFile(unittest.TestCase):
     @classmethod
@@ -170,13 +358,13 @@ class PolicyGeneratingArmParametersCleanRoomTarFile(unittest.TestCase):
         )[0]
 
         regular_image.populate_policy_content_for_all_images()
-
+        SecurityPolicyProxy.layer_cache = {}
         clean_room_image = load_policy_from_arm_template_str(
             custom_arm_json_default_value, ""
         )[0]
 
         try:
-            filename = os.path.join(self.path, "./mariner.tar")
+            filename = os.path.join(self.path, "mariner.tar")
             tar_mapping_file = {"mcr.microsoft.com/aks/e2e/library-busybox:master.220314.1-linux-amd64": filename}
             create_tar_file(filename)
             clean_room_image.populate_policy_content_for_all_images(
@@ -376,7 +564,7 @@ class PolicyGeneratingArmParametersCleanRoomTarFile(unittest.TestCase):
         )[0]
 
         regular_image.populate_policy_content_for_all_images()
-
+        SecurityPolicyProxy.layer_cache = {}
         clean_room_image = load_policy_from_arm_template_str(
             custom_arm_json_default_value, ""
         )[0]
@@ -400,7 +588,6 @@ class PolicyGeneratingArmParametersCleanRoomTarFile(unittest.TestCase):
         regular_image_json[1].pop(config.POLICY_FIELD_CONTAINERS_ID)
         clean_room_json[1].pop(config.POLICY_FIELD_CONTAINERS_ID)
 
-        # see if the remote image and the local one produce the same output
         self.assertEqual(
             deepdiff.DeepDiff(regular_image_json, clean_room_json, ignore_order=True),
             {},

--- a/src/confcom/setup.py
+++ b/src/confcom/setup.py
@@ -19,7 +19,7 @@ except ImportError:
 
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
 
-VERSION = "1.2.1"
+VERSION = "1.2.2"
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
confcom previously relied on the `manifest.json` file that is created when saving tar files from docker. This file is not present when downloading/saving via podman, skopeo, oras, and potentially other open-source tools. This update supports OCI images while preserving the capability of using docker-formatted tar files.

Note that one limitation of OCI tar files is their inability to contain multiple images. This is now referenced in the example documentation.