### PR TITLE
Vn2 fragments

### DIFF
--- a/src/confcom/HISTORY.rst
+++ b/src/confcom/HISTORY.rst
@@ -2,6 +2,11 @@
 
 Release History
 ===============
+
+1.2.3
+++++++
+* adding fragment support for VN2
+
 1.2.2
 ++++++
 * support for pure OCI v1 schema 2 formatted images

--- a/src/confcom/azext_confcom/README.md
+++ b/src/confcom/azext_confcom/README.md
@@ -277,6 +277,29 @@ Use the following command to generate and print a security policy for an AKS pod
 az confcom acipolicygen --virtual-node-yaml ./pod.yaml --print-policy
 ```
 
+To generate a security policy using a policy config file for Virtual Node, the `scenario` field must be equal to `"vn2"`. This looks like:
+
+```json
+{
+    "version": "1.0",
+    "scenario": "vn2",
+    "containers": [
+        {
+            "name": "my-image",
+            "properties": {
+                "image": "mcr.microsoft.com/acc/samples/aci/helloworld:2.8"
+            }
+        }
+    ]
+}
+```
+
+This `scenario` field adds the necessary environment variables and mount values to containers in the config file.
+
+### Workload Identity
+
+To use workload identities with VN2, the associated label [described here](https://learn.microsoft.com/en-us/azure/aks/workload-identity-overview?tabs=dotnet#pod-labels) must be present. Having this will add the requisite environment variables and mounts to each container's policy.
+
 > [!NOTE]
 > The `acipolicygen` command is specific to generating policies for ACI-based containers. For generating security policies for the [Confidential Containers on AKS](https://learn.microsoft.com/en-us/azure/aks/confidential-containers-overview) feature, use the `katapolicygen` command.
 

--- a/src/confcom/azext_confcom/_params.py
+++ b/src/confcom/azext_confcom/_params.py
@@ -24,6 +24,7 @@ from azext_confcom._validators import (
     validate_fragment_json_policy,
     validate_image_target,
     validate_upload_fragment,
+    validate_infrastructure_svn,
 )
 
 
@@ -88,6 +89,7 @@ def load_arguments(self, _):
             options_list=("--infrastructure-svn",),
             required=False,
             help="Minimum Allowed Software Version Number for Infrastructure Fragment",
+            validator=validate_infrastructure_svn,
         )
         c.argument(
             "debug_mode",

--- a/src/confcom/azext_confcom/_validators.py
+++ b/src/confcom/azext_confcom/_validators.py
@@ -24,6 +24,11 @@ def validate_print_format(namespace):
         raise CLIError("Can only print in one format at a time")
 
 
+def validate_infrastructure_svn(namespace):
+    if namespace.infrastructure_svn and namespace.exclude_default_fragments:
+        raise CLIError("Cannot set infrastructure SVN without using default fragments")
+
+
 def validate_aci_source(namespace):
     if sum(map(bool, [
         namespace.input_path,

--- a/src/confcom/azext_confcom/config.py
+++ b/src/confcom/azext_confcom/config.py
@@ -11,6 +11,7 @@ ACI_FIELD_VERSION = "version"
 ACI_FIELD_RESOURCES = "resources"
 ACI_FIELD_RESOURCES_NAME = "name"
 ACI_FIELD_CONTAINERS = "containers"
+ACI_FIELD_SCENARIO = "scenario"
 ACI_FIELD_CONTAINERS_NAME = "name"
 ACI_FIELD_CONTAINERS_CONTAINERIMAGE = "containerImage"
 ACI_FIELD_CONTAINERS_ENVS = "environmentVariables"
@@ -162,6 +163,11 @@ POLICY_FIELD_CONTAINERS_ELEMENTS_MOUNTS_CONFIGMAP_LOCATION = "/mnt/configmap"
 POLICY_FIELD_CONTAINERS_ELEMENTS_MOUNTS_CONFIGMAP_TYPE = "emptyDir"
 REGO_CONTAINER_START = "containers := "
 REGO_FRAGMENT_START = "fragments := "
+
+# scenario options
+VN2 = "vn2"
+ACI = "aci"
+KATA = "kata"
 
 
 CONFIG_FILE = "./data/internal_config.json"

--- a/src/confcom/azext_confcom/container.py
+++ b/src/confcom/azext_confcom/container.py
@@ -525,7 +525,7 @@ def extract_get_signals(container_json: Any) -> List:
 
 
 class ContainerImage:
-    # pylint: disable=too-many-instance-attributes
+    # pylint: disable=too-many-instance-attributes, too-many-public-methods
 
     @classmethod
     def from_json(
@@ -667,6 +667,9 @@ class ContainerImage:
     def get_mounts(self) -> List:
         return self._mounts
 
+    def set_mounts(self, mounts) -> None:
+        self._mounts = mounts
+
     def get_seccomp_profile_sha256(self) -> str:
         return self._seccomp_profile_sha256
 
@@ -796,10 +799,11 @@ class UserContainerImage(ContainerImage):
             image.get_mounts().extend(_DEFAULT_MOUNTS_VN2)
 
         # Start with the customer environment rules
-        env_rules = _INJECTED_CUSTOMER_ENV_RULES
+        env_rules = copy.deepcopy(_INJECTED_CUSTOMER_ENV_RULES)
         # If is_vn2, add the VN2 environment rules
         if is_vn2:
             env_rules += _INJECTED_SERVICE_VN2_ENV_RULES
+            image.set_mounts(image.get_mounts() + copy.deepcopy(config.DEFAULT_MOUNTS_VIRTUAL_NODE))
 
         image.set_extra_environment_rules(env_rules)
         return image

--- a/src/confcom/azext_confcom/custom.py
+++ b/src/confcom/azext_confcom/custom.py
@@ -144,7 +144,10 @@ def acipolicygen_confcom(
             debug_mode=debug_mode,
             disable_stdio=disable_stdio,
             approve_wildcards=approve_wildcards,
-            diff_mode=diff
+            diff_mode=diff,
+            rego_imports=fragments_list,
+            exclude_default_fragments=exclude_default_fragments,
+            infrastructure_svn=infrastructure_svn,
         )
 
     exit_code = 0

--- a/src/confcom/azext_confcom/tests/latest/test_confcom_virtual_node.py
+++ b/src/confcom/azext_confcom/tests/latest/test_confcom_virtual_node.py
@@ -6,13 +6,19 @@
 import os
 import unittest
 import json
+import subprocess
 import azext_confcom.config as config
+import azext_confcom.os_util as os_util
 from azext_confcom.template_util import extract_containers_from_text
 from azext_confcom.security_policy import (
     load_policy_from_str,
     load_policy_from_virtual_node_yaml_str,
     OutputType,
     decompose_confidential_properties
+)
+from azext_confcom.custom import (
+    acipolicygen_confcom,
+    acifragmentgen_confcom,
 )
 
 TEST_DIR = os.path.abspath(os.path.join(os.path.abspath(__file__), ".."))
@@ -53,6 +59,44 @@ class PolicyGeneratingVirtualNode(unittest.TestCase):
             ]
         }
         """
+    custom_json2 = """
+{
+  "version": "1.0",
+  "fragments": [],
+  "scenario": "vn2",
+  "containers": [
+    {
+      "name": "simple-container",
+      "properties": {
+        "image": "mcr.microsoft.com/cbl-mariner/distroless/python:3.9-nonroot",
+        "environmentVariables": [
+          {
+            "name": "PATH",
+            "value": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+          }
+        ],
+        "command": [
+          "python3"
+        ],
+        "volumeMounts": [
+          {
+            "name": "logs",
+            "mountType": "emptyDir",
+            "mountPath": "/aci/logs",
+            "readonly": false
+          },
+          {
+            "name": "secret",
+            "mountType": "emptyDir",
+            "mountPath": "/aci/secret",
+            "readonly": true
+          }
+        ]
+      }
+    }
+  ]
+}
+    """
 
     custom_yaml = """
 apiVersion: v1
@@ -295,6 +339,30 @@ spec:
         - containerPort: 80
           name: web
 """
+    @classmethod
+    def setUpClass(cls):
+        cls.key_dir_parent = os.path.join(TEST_DIR, '..', '..', '..', 'samples', 'certs')
+        cls.key = os.path.join(cls.key_dir_parent, 'intermediateCA', 'private', 'ec_p384_private.pem')
+        cls.chain = os.path.join(cls.key_dir_parent, 'intermediateCA', 'certs', 'www.contoso.com.chain.cert.pem')
+        if not os.path.exists(cls.key) or not os.path.exists(cls.chain):
+            script_path = os.path.join(cls.key_dir_parent, 'create_certchain.sh')
+
+            arg_list = [
+                script_path,
+            ]
+            os.chmod(script_path, 0o755)
+
+            # NOTE: this will raise an exception if it's run on windows and the key/cert files don't exist
+            item = subprocess.run(
+                arg_list,
+                check=False,
+                shell=True,
+                cwd=cls.key_dir_parent,
+                env=os.environ.copy(),
+            )
+
+            if item.returncode != 0:
+                raise Exception("Error creating certificate chain")
 
     def test_compare_policy_sources(self):
         custom_policy = load_policy_from_str(self.custom_json)
@@ -312,6 +380,59 @@ spec:
         self.assertEqual(custom_containers[0].get("layers"), virtual_node_containers[0].get("layers"))
         # test the image command
         self.assertEqual(custom_containers[0].get("command"), virtual_node_containers[0].get("command"))
+
+
+    def test_virtual_node_policy_fragments(self):
+        try:
+          fragment_filename = "policy_file.json"
+          yaml_filename = "policy_file.yaml"
+          os_util.write_str_to_file(fragment_filename, self.custom_json2)
+          os_util.write_str_to_file(yaml_filename, self.custom_yaml)
+          rego_filename = "example_file"
+          acifragmentgen_confcom(None, fragment_filename, None, rego_filename, "1", "test_feed_file", self.key, self.chain, None)
+
+          # create import file
+          import_filename = "my_fragments.json"
+          signed_file_path = f"{rego_filename}.rego.cose"
+          acifragmentgen_confcom(None, None, None, None, None, None, None, None, "1", fragment_path=signed_file_path, generate_import=True, fragments_json=import_filename)
+          # add path into the fragment import
+          import_data = os_util.load_json_from_file(import_filename)
+          import_data[config.POLICY_FIELD_CONTAINERS_ELEMENTS_REGO_FRAGMENTS][0][config.POLICY_FIELD_CONTAINERS_ELEMENTS_REGO_FRAGMENTS_PATH] = signed_file_path
+          os_util.write_json_to_file(import_filename, import_data)
+
+          # create policy using import statement
+          acipolicygen_confcom(None, None, None, None, yaml_filename, None, None, fragments_json=import_filename, exclude_default_fragments=True, include_fragments=True)
+
+          # count all the vn2 specific env vars to amke sure they're all there
+          fragment_content = os_util.str_to_base64(os_util.load_str_from_file(f"{rego_filename}.rego"))
+          containers, _ = decompose_confidential_properties(fragment_content)
+
+          env_vars = containers[0].get(config.POLICY_FIELD_CONTAINERS_ELEMENTS_ENVS)
+
+          vn2_env_var_count = 0
+          vn2_env_vars = [x.get(config.POLICY_FIELD_CONTAINERS_ELEMENTS_ENVS_NAME) for x in config.VIRTUAL_NODE_ENV_RULES]
+
+          for env_var in env_vars:
+              name = env_var.get(config.POLICY_FIELD_CONTAINERS_ELEMENTS_ENVS_RULE).split("=")[0]
+              if name in vn2_env_vars:
+                  vn2_env_var_count += 1
+          self.assertEqual(len(vn2_env_vars), vn2_env_var_count)
+
+          output_yaml = os_util.load_yaml_from_file(yaml_filename)
+          output_containers, output_fragments = decompose_confidential_properties(output_yaml.get(config.VIRTUAL_NODE_YAML_METADATA).get(config.VIRTUAL_NODE_YAML_ANNOTATIONS).get(config.VIRTUAL_NODE_YAML_POLICY))
+
+          self.assertTrue(config.DEFAULT_REGO_FRAGMENTS not in output_fragments)
+          for container in output_containers:
+              if container.get(config.POLICY_FIELD_CONTAINERS_NAME) == "simple-container":
+                  self.fail("policy contains container covered by fragment")
+        finally:
+
+          os_util.force_delete_silently(fragment_filename)
+          os_util.force_delete_silently(yaml_filename)
+          os_util.force_delete_silently(import_filename)
+          os_util.force_delete_silently(signed_file_path)
+          os_util.force_delete_silently(f"{rego_filename}.rego")
+
 
     def test_configmaps(self):
         virtual_node_policy = load_policy_from_virtual_node_yaml_str(self.custom_yaml_configmap)[0]


### PR DESCRIPTION
Since VN2 and fragments were developed concurrently, this functionality hadn't been considered. This PR closes the gap between using fragments for VN2 vs. Confidential ACI. Usage is the same as confidential ACI but using `--virtual-node-yaml` instead of `--template-file`.

Ex)
`az confcom acipolicygen --virtual-node-yaml <yaml-path> --include-fragments --fragments-json <fragment-import-path>`