### PR TITLE
Refactor code for fragments and policies to use same function

### DIFF
--- a/src/confcom/azext_confcom/cose_proxy.py
+++ b/src/confcom/azext_confcom/cose_proxy.py
@@ -143,8 +143,7 @@ class CoseSignToolProxy:  # pylint: disable=too-few-public-methods
         return item.stdout.decode("utf-8")
 
     # generate an import statement from a signed policy fragment
-    def generate_import_from_path(self, fragment_path: str, minimum_svn: int) -> str:
-        # TODO: make sure the fragment is signed correctly
+    def generate_import_from_path(self, fragment_path: str, minimum_svn: str) -> str:
         if not os.path.exists(fragment_path):
             eprint(f"The fragment file at {fragment_path} does not exist")
 

--- a/src/confcom/azext_confcom/custom.py
+++ b/src/confcom/azext_confcom/custom.py
@@ -115,7 +115,7 @@ def acipolicygen_confcom(
     )
     # error checking for making sure an input is provided is above
     if input_path:
-        container_group_policies = security_policy.load_policy_from_file(
+        container_group_policies = security_policy.load_policy_from_json_file(
             input_path,
             debug_mode=debug_mode,
             infrastructure_svn=infrastructure_svn,
@@ -228,7 +228,7 @@ def acifragmentgen_confcom(
     feed: str,
     key: str,
     chain: str,
-    minimum_svn: int,
+    minimum_svn: str,
     image_target: str = "",
     algo: str = "ES384",
     fragment_path: str = None,
@@ -292,7 +292,7 @@ def acifragmentgen_confcom(
         # this is using --input
         if not tar_mapping:
             tar_mapping = os_util.load_tar_mapping_from_config_file(input_path)
-        policy = security_policy.load_policy_from_config_file(
+        policy = security_policy.load_policy_from_json_file(
             input_path, debug_mode=debug_mode, disable_stdio=disable_stdio
         )
     # get all of the fragments that are being used in the policy

--- a/src/confcom/azext_confcom/oras_proxy.py
+++ b/src/confcom/azext_confcom/oras_proxy.py
@@ -175,7 +175,7 @@ def attach_fragment_to_image(image_name: str, filename: str):
     print(f"Fragment attached to image '{image_name}' with Digest:{digest}")
 
 
-def generate_imports_from_image_name(image_name: str, minimum_svn: int) -> List[dict]:
+def generate_imports_from_image_name(image_name: str, minimum_svn: str) -> List[dict]:
     cose_proxy = CoseSignToolProxy()
     fragment_hashes = discover(image_name)
     import_list = []

--- a/src/confcom/azext_confcom/tests/latest/README.md
+++ b/src/confcom/azext_confcom/tests/latest/README.md
@@ -19,30 +19,30 @@ It uses the ARM template used to deploy a ACI Container Group while taking into 
 
 Test Name | Image Used | Purpose
 ---|---|---
-test_arm_template_policy | mcr.microsoft.com/cbl-mariner/distroless/python:3.9-nonroot | Generate an ARM Template policy and policy.json policy and see if their outputs match
-test_default_infrastructure_svn | mcr.microsoft.com/cbl-mariner/distroless/python:3.9-nonroot | See the default value of the minimum SVN for the infrastructure fragment
-test_default_pause_container | mcr.microsoft.com/cbl-mariner/distroless/python:3.9-nonroot | See if the default pause containers match the config
+test_arm_template_policy | mcr.microsoft.com/azurelinux/base/python:3.12 | Generate an ARM Template policy and policy.json policy and see if their outputs match
+test_default_infrastructure_svn | mcr.microsoft.com/azurelinux/base/python:3.12 | See the default value of the minimum SVN for the infrastructure fragment
+test_default_pause_container | mcr.microsoft.com/azurelinux/base/python:3.12 | See if the default pause containers match the config
 test_arm_template_missing_image_name | N/A | Error condition if an image isn't specified
 test_arm_template_missing_resources | N/A | Error condition where no resources are specified to deploy
 test_arm_template_missing_aci | N/A | Error condition where ACI is not specified in resources
 test_arm_template_missing_containers | N/A | Error condition where there are no containers in the ACI resource
-test_arm_template_missing_definition | mcr.microsoft.com/cbl-mariner/distroless/python:3.9-nonroot | Error condition where image is specified in template.parameters.json but not in template.json
+test_arm_template_missing_definition | mcr.microsoft.com/azurelinux/base/python:3.12 | Error condition where image is specified in template.parameters.json but not in template.json
 test_arm_template_with_parameter_file | mcr.microsoft.com/azure-functions/python:4-python3.8 | Condition where image in template.parameters.json overwrites image name in template.json
 test_arm_template_with_parameter_file_injected_env_vars | mcr.microsoft.com/azure-functions/python:4-python3.8 | See if env vars from the image are injected into the policy. Also make sure the `concat` function in ARM template won't break the CLI if it's not in a required spot like image name
 test_arm_template_with_parameter_file_arm_config | mcr.microsoft.com/azure-functions/python:4-python3.8 | Test valid case of using a parameter file with JSON output instead of Rego
 test_arm_template_with_parameter_file_clean_room | mcr.microsoft.com/azure-functions/node:4 | Test clean room case where image specified does not exist remotely but does locally
-test_policy_diff | mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0 | See if the diff functionality outputs `True` when diffs match completely
-test_incorrect_policy_diff | mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0 | Check output formatting and functionality of diff command
-test_update_infrastructure_svn | mcr.microsoft.com/cbl-mariner/distroless/python:3.9-nonroot | Change the minimum SVN for the insfrastructure fragment
-test_multiple_policies | mcr.microsoft.com/cbl-mariner/distroless/python:3.9-nonroot & mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0 | See if two unique policies are generated from a single ARM Template container multiple container groups. Also have an extra resource that is untouched. Also has a secureValue for an environment variable.
-test_arm_template_with_init_container | mcr.microsoft.com/cbl-mariner/distroless/python:3.9-nonroot & mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0 | See if having an initContainer is picked up and added to the list of valid containers
-test_arm_template_without_stdio_access | mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0 | See if disabling container stdio access gets passed down to individual containers
-test_arm_template_omit_id | mcr.microsoft.com/cbl-mariner/distroless/python:3.9-nonroot | Check that the id field is omitted from the policy
-test_arm_template_allow_elevated_false | mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0 | Disabling allow_elevated via securityContext
-test_arm_template_policy_regex | mcr.microsoft.com/cbl-mariner/distroless/python:3.9-nonroot | Make sure the regex generated from the ARM Template workflow matches that of the policy.json workflow
-test_wildcard_env_var | mcr.microsoft.com/cbl-mariner/distroless/python:3.9-nonroot | Check that an "allow all" regex is created when a value for env var is not provided via a parameter value
+test_policy_diff | mcr.microsoft.com/azurelinux/distroless/base:3.0 | See if the diff functionality outputs `True` when diffs match completely
+test_incorrect_policy_diff | mcr.microsoft.com/azurelinux/distroless/base:3.0 | Check output formatting and functionality of diff command
+test_update_infrastructure_svn | mcr.microsoft.com/azurelinux/base/python:3.12 | Change the minimum SVN for the insfrastructure fragment
+test_multiple_policies | mcr.microsoft.com/azurelinux/base/python:3.12 & mcr.microsoft.com/azurelinux/distroless/base:3.0 | See if two unique policies are generated from a single ARM Template container multiple container groups. Also have an extra resource that is untouched. Also has a secureValue for an environment variable.
+test_arm_template_with_init_container | mcr.microsoft.com/azurelinux/base/python:3.12 & mcr.microsoft.com/azurelinux/distroless/base:3.0 | See if having an initContainer is picked up and added to the list of valid containers
+test_arm_template_without_stdio_access | mcr.microsoft.com/azurelinux/distroless/base:3.0 | See if disabling container stdio access gets passed down to individual containers
+test_arm_template_omit_id | mcr.microsoft.com/azurelinux/base/python:3.12 | Check that the id field is omitted from the policy
+test_arm_template_allow_elevated_false | mcr.microsoft.com/azurelinux/distroless/base:3.0 | Disabling allow_elevated via securityContext
+test_arm_template_policy_regex | mcr.microsoft.com/azurelinux/base/python:3.12 | Make sure the regex generated from the ARM Template workflow matches that of the policy.json workflow
+test_wildcard_env_var | mcr.microsoft.com/azurelinux/base/python:3.12 | Check that an "allow all" regex is created when a value for env var is not provided via a parameter value
 test_wildcard_env_var_invalid | N/A | Make sure the process errors out if a value is not given for an env var or an undefined parameter is used for the name of an env var
-test_arm_template_with_env_var | mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0 | Make sure that a value that looks similar to but is not an ARM parameter is treated as a string
+test_arm_template_with_env_var | mcr.microsoft.com/azurelinux/distroless/base:3.0 | Make sure that a value that looks similar to but is not an ARM parameter is treated as a string
 test_arm_template_security_context_defaults | N/A | Make sure default values for securityContext are correct
 test_arm_template_security_context_allow_privilege_escalation | N/A | See if changing the allowPrivilegeEscalation flag is working
 test_arm_template_security_context_user | N/A | Set the user field manually to make sure it is reflected in the policy
@@ -57,7 +57,7 @@ test_arm_template_security_context_user_group | N/A | See if user is set correct
 test_arm_template_security_context_uid_group | N/A | See if user is set correctly by getting the user field from the Docker image in the format uid:group
 test_arm_template_security_context_uid | N/A | See if user is set correctly by getting the user field from the Docker image in the format uid
 test_arm_template_security_context_user_dockerfile | N/A | See if user is set correctly by getting the user field from the Docker image in the format user
-test_zero_sidecar | mcr.microsoft.com/cbl-mariner/distroless/python:3.9-nonroot | Make sure the infrastructure fragment is taken out when the appropriate tag is present in an ARM template
+test_zero_sidecar | mcr.microsoft.com/azurelinux/base/python:3.12 | Make sure the infrastructure fragment is taken out when the appropriate tag is present in an ARM template
 
 ## policy.json [test file](test_confcom_scenario.py)
 
@@ -66,31 +66,31 @@ It is still used for generating sidecar CCE Policies.
 
 Test Name | Image Used | Purpose
 ---|---|---
-test_user_container_customized_mounts | mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0 | See if mounts are translated correctly to the appropriate source and destination locations
-test_user_container_mount_injected_dns | mcr.microsoft.com/cbl-mariner/distroless/python:3.9-nonroot | See if the resolvconf mount works properly
+test_user_container_customized_mounts | mcr.microsoft.com/azurelinux/distroless/base:3.0 | See if mounts are translated correctly to the appropriate source and destination locations
+test_user_container_mount_injected_dns | mcr.microsoft.com/azurelinux/base/python:3.12 | See if the resolvconf mount works properly
 test_injected_sidecar_container_msi | mcr.microsoft.com/aci/msi-atlas-adapter:master_20201203.1 | Make sure User mounts and env vars aren't added to sidecar containers, using JSON output format
-test_debug_flags | mcr.microsoft.com/cbl-mariner/distroless/python:3.9-nonroot | Enable flags set via debug_mode
+test_debug_flags | mcr.microsoft.com/azurelinux/base/python:3.12 | Enable flags set via debug_mode
 test_sidecar | mcr.microsoft.com/aci/msi-atlas-adapter:master_20201210.1 | See if sidecar validation would pass policy created by given policy.json
 test_sidecar_stdio_access_default | mcr.microsoft.com/aci/msi-atlas-adapter:master_20201210.1 | Check that sidecar containers have std I/O access by default
 test_incorrect_sidecar | mcr.microsoft.com/aci/msi-atlas-adapter:master_20201210.1 | See what output format for failing sidecar validation would be
-test_customized_workingdir | mcr.microsoft.com/cbl-mariner/distroless/python:3.9-nonroot | Using different working dir than specified in image metadata
-test_allow_elevated | mcr.microsoft.com/cbl-mariner/distroless/python:3.9-nonroot | Using allow_elevated in container
-test_image_layers_python | mcr.microsoft.com/cbl-mariner/distroless/python:3.9-nonroot | Make sure image layers are as expected
-test_docker_pull | mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0 | Test pulling an image from docker client
-test_infrastructure_svn | mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0 | make sure the correct infrastructure_svn is present in the policy
-test_stdio_access_default | mcr.microsoft.com/cbl-mariner/distroless/python:3.9-nonroot | Checking the default value for std I/O access
-test_stdio_access_updated | mcr.microsoft.com/cbl-mariner/distroless/python:3.9-nonroot | Checking the value for std I/O when it's set
-test_omit_id | mcr.microsoft.com/cbl-mariner/distroless/python:3.9-nonroot | Check that the id field is omitted from the policy
-test_environment_variables_parsing | mcr.microsoft.com/azuredocs/aci-dataprocessing-cc:v1 | Make sure env vars are output in the right format
+test_customized_workingdir | mcr.microsoft.com/azurelinux/base/python:3.12 | Using different working dir than specified in image metadata
+test_allow_elevated | mcr.microsoft.com/azurelinux/base/python:3.12 | Using allow_elevated in container
+test_image_layers_python | mcr.microsoft.com/azurelinux/base/python:3.12 | Make sure image layers are as expected
+test_docker_pull | mcr.microsoft.com/azurelinux/distroless/base:3.0 | Test pulling an image from docker client
+test_infrastructure_svn | mcr.microsoft.com/azurelinux/distroless/base:3.0 | make sure the correct infrastructure_svn is present in the policy
+test_stdio_access_default | mcr.microsoft.com/azurelinux/base/python:3.12 | Checking the default value for std I/O access
+test_stdio_access_updated | mcr.microsoft.com/azurelinux/base/python:3.12 | Checking the value for std I/O when it's set
+test_omit_id | mcr.microsoft.com/azurelinux/base/python:3.12 | Check that the id field is omitted from the policy
+test_environment_variables_parsing | mcr.microsoft.com/azurelinux/distroless/base:3.0 | Make sure env vars are output in the right format
 test_get_layers_from_not_exists_image | notexists:1.0.0 | Fail out grabbing layers if image doesn't exist
-test_incorrect_allow_elevated_data_type | mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0 | Making allow_elevated fail out if it's not a boolean
-test_incorrect_workingdir_path | mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0 | Fail if working dir isn't an absolute path string
-test_incorrect_workingdir_data_type | mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0 | Fail if working dir is an array
-test_incorrect_command_data_type | mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0 | Fail if command is not array of strings
+test_incorrect_allow_elevated_data_type | mcr.microsoft.com/azurelinux/distroless/base:3.0 | Making allow_elevated fail out if it's not a boolean
+test_incorrect_workingdir_path | mcr.microsoft.com/azurelinux/distroless/base:3.0 | Fail if working dir isn't an absolute path string
+test_incorrect_workingdir_data_type | mcr.microsoft.com/azurelinux/distroless/base:3.0 | Fail if working dir is an array
+test_incorrect_command_data_type | mcr.microsoft.com/azurelinux/distroless/base:3.0 | Fail if command is not array of strings
 test_json_missing_containers | N/A | Fail if containers are not specified
 test_json_missing_containerImage | N/A | Fail if container doesn't have an image specified
-test_json_missing_environmentVariables | mcr.microsoft.com/azuredocs/aci-dataprocessing-cc:v1 | Fail if there are no env vars defined
-test_json_missing_command | mcr.microsoft.com/azuredocs/aci-dataprocessing-cc:v1 | Fail if there is no command specified
+test_json_missing_environmentVariables | mcr.microsoft.com/azurelinux/distroless/base:3.0 | Fail if there are no env vars defined
+test_json_missing_command | mcr.microsoft.com/azurelinux/distroless/base:3.0 | Fail if there is no command specified
 
 ## Image [test file](test_confcom_image.py)
 
@@ -99,7 +99,7 @@ It accepts a string of the image name and tag and outputs a CCE Policy using the
 
 Test Name | Image Used | Purpose
 ---|---|---
-test_image_policy | mcr.microsoft.com/cbl-mariner/distroless/python:3.9-nonroot | Create a policy based on only an image name
+test_image_policy | mcr.microsoft.com/azurelinux/base/python:3.12 | Create a policy based on only an image name
 test_sidecar_image_policy |mcr.microsoft.com/aci/atlas-mount-azure-file-volume:master_20201210.2| Create a policy based on a sidecar so no env vars are injected
 test_invalid_image_policy | mcr.microsoft.com/aci/fake-image:master_20201210.2 | Fail out if the image doesn't exist locally or remotely
 test_clean_room_policy | mcr.microsoft.com/aci/atlas-mount-azure-file-volume:master_20201210.2 | create a new tag of a sidecar locally and make sure it matches the original
@@ -123,8 +123,8 @@ This is a way to generate a CCE policy without the use of the docker daemon. The
 
 Test Name | Image Used | Purpose
 ---|---|---
-test_arm_template_with_parameter_file_clean_room_tar | mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0 | Create a policy from a tar file and compare it to a policy generated from an ARM template
-test_arm_template_mixed_mode_tar | mcr.microsoft.com/cbl-mariner/distroless/python:3.9-nonroot & mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0 | Create a policy with one image from a tar file and one image that must be downloaded or used locally from the daemon
+test_arm_template_with_parameter_file_clean_room_tar | mcr.microsoft.com/azurelinux/distroless/base:3.0 | Create a policy from a tar file and compare it to a policy generated from an ARM template
+test_arm_template_mixed_mode_tar | mcr.microsoft.com/azurelinux/base/python:3.12 & mcr.microsoft.com/azurelinux/distroless/base:3.0 | Create a policy with one image from a tar file and one image that must be downloaded or used locally from the daemon
 test_arm_template_with_parameter_file_clean_room_tar_invalid | N/A | Fail out if searching for an image in a tar file that does not include it
 test_clean_room_fake_tar_invalid | N/A | Fail out if the path to the tar file doesn't exist
 
@@ -146,9 +146,9 @@ This is how to generate security policies for Virtual Nodes on AKS
 
 Test Name | Image Used | Purpose
 ---|---|---
-test_compare_policy_sources | mcr.microsoft.com/cbl-mariner/distroless/python:3.9-nonroot | Compare the output of a policy generated from a Virtual Node file and a policy generated from an input json
-test_configmaps | mcr.microsoft.com/cbl-mariner/distroless/python:3.9-nonroot | Check that the configmaps are being added to the policy in env var and mount form
-test_secrets | mcr.microsoft.com/cbl-mariner/distroless/python:3.9-nonroot | Check that the secrets are being added to the policy in env var and mount form
+test_compare_policy_sources | mcr.microsoft.com/azurelinux/base/python:3.12 | Compare the output of a policy generated from a Virtual Node file and a policy generated from an input json
+test_configmaps | mcr.microsoft.com/azurelinux/base/python:3.12 | Check that the configmaps are being added to the policy in env var and mount form
+test_secrets | mcr.microsoft.com/azurelinux/base/python:3.12 | Check that the secrets are being added to the policy in env var and mount form
 
 ## Fragment File [test file](test_confcom_fragment.py)
 
@@ -156,15 +156,28 @@ This is how to generate a policy fragment to be included in a CCE Policy for Con
 
 Test Name | Image Used | Purpose
 ---|---|---
-test_fragment_user_container_customized_mounts | mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0 | See if mounts are translated correctly to the appropriate source and destination locations
-test_fragment_user_container_mount_injected_dns | mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0 | See if the resolvconf mount works properly
+test_fragment_user_container_customized_mounts | mcr.microsoft.com/azurelinux/distroless/base:3.0 | See if mounts are translated correctly to the appropriate source and destination locations
+test_fragment_user_container_mount_injected_dns | mcr.microsoft.com/azurelinux/distroless/base:3.0 | See if the resolvconf mount works properly
 test_fragment_omit_id | mcr.microsoft.com/aci/msi-atlas-adapter:master_20201203.1 | Check that the id field is omitted from the policy
 test_fragment_injected_sidecar_container_msi | mcr.microsoft.com/aci/msi-atlas-adapter:master_20201203.1 | Make sure User mounts and env vars aren't added to sidecar containers, using JSON output format
-test_debug_processes | mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0 | Enable exec_processes via debug_mode
+test_debug_processes | mcr.microsoft.com/azurelinux/distroless/base:3.0 | Enable exec_processes via debug_mode
 test_fragment_sidecar | mcr.microsoft.com/aci/msi-atlas-adapter:master_20201210.1 | See if sidecar fragments can be created by a given policy.json
 test_fragment_sidecar_stdio_access_default | mcr.microsoft.com/aci/msi-atlas-adapter:master_20201210.1 | Check that sidecar containers have std I/O access by default
 test_fragment_incorrect_sidecar | mcr.microsoft.com/aci/msi-atlas-adapter:master_20201210.1 | See what output format for failing sidecar validation would be
-test_signing | mcr.microsoft.com/acc/samples/aci/helloworld:2.8 | Sign a fragment with a key and chain file
-test_generate_import | mcr.microsoft.com/acc/samples/aci/helloworld:2.8 | Generate an import statement for the signed fragment file
-test_local_fragment_references | mcr.microsoft.com/acc/samples/aci/helloworld:2.8 | Make sure the fragment references are correct when the fragment is local
+test_signing | mcr.microsoft.com/acc/samples/aci/helloworld:2.9 | Sign a fragment with a key and chain file
+test_generate_import | mcr.microsoft.com/acc/samples/aci/helloworld:2.9 | Generate an import statement for the signed fragment file
+test_local_fragment_references | mcr.microsoft.com/acc/samples/aci/helloworld:2.9 | Make sure the fragment references are correct when the fragment is local
 test_invalid_input | mcr.microsoft.com/aci/msi-atlas-adapter:master_20201210.1 | Fail out under various invalid input circumstances
+
+## Policy Conversion File [test file](test_confcom_policy_conversion.py)
+
+Test Name | Image Used | Purpose
+---|---|---
+test_detect_old_format | N/A | Verify that old and new format configurations are correctly identified
+test_top_level_fields_propagated | N/A | Check that top-level fields like version and fragments are preserved during conversion
+test_container_count_preserved | N/A | Ensure the number of containers remains unchanged after conversion
+test_env_strategy_to_regex_flag | N/A | Verify environment variable strategy is correctly translated to regex flags in v1 format
+test_exec_processes_built_correctly | N/A | Check command and probe commands are correctly aggregated into execProcesses
+test_volume_mount_basic_fields | N/A | Test volume mount properties are correctly translated to the new format
+test_workingdir_and_allow_elevated_migrated | N/A | Verify workingDir and allow_elevated are correctly moved to security context
+test_already_v1_returns_same_object | N/A | Confirm conversion is idempotent - v1 format input remains unchanged

--- a/src/confcom/azext_confcom/tests/latest/test_confcom_arm.py
+++ b/src/confcom/azext_confcom/tests/latest/test_confcom_arm.py
@@ -11,7 +11,7 @@ from unittest.mock import patch
 
 from azext_confcom.security_policy import (
     OutputType,
-    load_policy_from_str,
+    load_policy_from_json,
     load_policy_from_arm_template_str,
 )
 import azext_confcom.config as config
@@ -33,7 +33,7 @@ class PolicyGeneratingArm(unittest.TestCase):
             "containers": [
                 {
                     "name": "simple-container",
-                    "containerImage": "mcr.microsoft.com/cbl-mariner/distroless/python:3.9-nonroot",
+                    "containerImage": "mcr.microsoft.com/azurelinux/base/python:3.12",
                     "environmentVariables": [
                         {
                             "name":"PATH",
@@ -65,7 +65,7 @@ class PolicyGeneratingArm(unittest.TestCase):
         "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
         "contentVersion": "1.0.0.0",
         "variables": {
-            "image": "mcr.microsoft.com/cbl-mariner/distroless/python:3.9-nonroot"
+            "image": "mcr.microsoft.com/azurelinux/base/python:3.12"
         },
 
 
@@ -204,7 +204,7 @@ class PolicyGeneratingArm(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        with load_policy_from_str(cls.custom_json) as aci_policy:
+        with load_policy_from_json(cls.custom_json) as aci_policy:
             aci_policy.populate_policy_content_for_all_images()
             cls.aci_policy = aci_policy
 
@@ -697,7 +697,7 @@ class PolicyGeneratingArmParametersIncorrect(unittest.TestCase):
         "contentVersion": "1.0.0.0",
         "parameters": {
             "image": {
-            "value": "mcr.microsoft.com/cbl-mariner/distroless/python:3.9-nonroot"
+            "value": "mcr.microsoft.com/azurelinux/base/python:3.12"
             },
             "containername": {
             "value": "simple-container"
@@ -758,7 +758,7 @@ class PolicyGeneratingArmParameters(unittest.TestCase):
                 "metadata": {
                     "description": "Name for the image"
                 },
-                "defaultValue": "mcr.microsoft.com/cbl-mariner/distroless/python:3.9-nonroot"
+                "defaultValue": "mcr.microsoft.com/azurelinux/base/python:3.12"
             },
 
             "port": {
@@ -898,7 +898,7 @@ class PolicyGeneratingArmParameters2(unittest.TestCase):
             "metadata": {
                 "description": "Name for the container group"
             },
-            "defaultValue":"mcr.microsoft.com/cbl-mariner/distroless/python:3.9-nonroot"
+            "defaultValue":"mcr.microsoft.com/azurelinux/base/python:3.12"
             },
              "imagebase": {
             "type": "string",
@@ -1078,7 +1078,7 @@ class PolicyGeneratingArmContainerConfig(unittest.TestCase):
             "metadata": {
                 "description": "Name for the container group"
             },
-            "defaultValue":"mcr.microsoft.com/cbl-mariner/distroless/python:3.9-nonroot"
+            "defaultValue":"mcr.microsoft.com/azurelinux/base/python:3.12"
             },
              "imagebase": {
             "type": "string",
@@ -1423,7 +1423,7 @@ class PolicyDiff(unittest.TestCase):
     "contentVersion": "1.0.0.0",
     "variables": {
         "container1name": "aci-test",
-        "container1image": "mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0"
+        "container1image": "mcr.microsoft.com/azurelinux/base/python:3.12"
     },
     "resources": [
         {
@@ -1502,7 +1502,7 @@ class PolicyDiff(unittest.TestCase):
     "contentVersion": "1.0.0.0",
     "variables": {
         "container1name": "aci-test",
-        "container1image": "mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0"
+        "container1image": "mcr.microsoft.com/azurelinux/base/python:3.12"
     },
     "resources": [
         {
@@ -1633,7 +1633,7 @@ class PolicyGeneratingArmInfrastructureSvn(unittest.TestCase):
         "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
         "contentVersion": "1.0.0.0",
         "variables": {
-            "image": "mcr.microsoft.com/cbl-mariner/distroless/python:3.9-nonroot"
+            "image": "mcr.microsoft.com/azurelinux/base/python:3.12"
         },
 
 
@@ -1801,9 +1801,9 @@ class MultiplePolicyTemplate(unittest.TestCase):
     "contentVersion": "1.0.0.0",
     "variables": {
         "container1name": "aci-test",
-        "container1image": "mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0",
+        "container1image": "mcr.microsoft.com/azurelinux/distroless/base:3.0",
         "container2name": "aci-test2",
-        "container2image": "mcr.microsoft.com/cbl-mariner/distroless/python:3.9-nonroot"
+        "container2image": "mcr.microsoft.com/azurelinux/base/python:3.12"
     },
     "resources": [
         {
@@ -1827,6 +1827,11 @@ class MultiplePolicyTemplate(unittest.TestCase):
                                     "memoryInGb": 1.5
                                 }
                             },
+                            "command": [
+                            "/bin/sh",
+                            "-c",
+                            "ls"
+                            ],
                             "ports": [
                                 {
                                     "port": 80
@@ -1887,6 +1892,11 @@ class MultiplePolicyTemplate(unittest.TestCase):
                         "name": "[variables('container2name')]",
                         "properties": {
                             "image": "[variables('container2image')]",
+                            "command": [
+                            "/bin/sh",
+                            "-c",
+                            "ls"
+                            ],
                             "resources": {
                                 "requests": {
                                     "cpu": 1,
@@ -1944,6 +1954,11 @@ class MultiplePolicyTemplate(unittest.TestCase):
                         "name": "aci-test-1",
                         "properties": {
                             "image": "[variables('container1image')]",
+                            "command": [
+                            "/bin/sh",
+                            "-c",
+                            "ls"
+                            ],
                             "resources": {
                                 "requests": {
                                     "cpu": 1,
@@ -1962,6 +1977,11 @@ class MultiplePolicyTemplate(unittest.TestCase):
                         "name": "aci-test-2",
                         "properties": {
                             "image": "[variables('container1image')]",
+                            "command": [
+                            "/bin/sh",
+                            "-c",
+                            "ls"
+                            ],
                             "resources": {
                                 "requests": {
                                     "cpu": 1,
@@ -1980,6 +2000,11 @@ class MultiplePolicyTemplate(unittest.TestCase):
                         "name": "aci-test-3",
                         "properties": {
                             "image": "[variables('container1image')]",
+                            "command": [
+                            "/bin/sh",
+                            "-c",
+                            "ls"
+                            ],
                             "resources": {
                                 "requests": {
                                     "cpu": 1,
@@ -2060,7 +2085,7 @@ class MultiplePolicyTemplate(unittest.TestCase):
         is_valid, diff = self.aci_policy.validate_cce_policy()
         self.assertFalse(is_valid)
         # just check to make sure the containers in both policies are different
-        expected_diff = {"aci-test": "mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0 not found in policy"}
+        expected_diff = {"aci-test": "mcr.microsoft.com/azurelinux/distroless/base:3.0 not found in policy"}
         self.assertEqual(diff, expected_diff)
 
     def test_multiple_diffs(self):
@@ -2097,7 +2122,7 @@ class PolicyGeneratingArmInitContainer(unittest.TestCase):
                 "metadata": {
                     "description": "Name for the container group"
                 },
-                "defaultValue":"mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0"
+                "defaultValue":"mcr.microsoft.com/azurelinux/distroless/base:3.0"
             },
             "containername": {
                 "type": "string",
@@ -2179,7 +2204,7 @@ class PolicyGeneratingArmInitContainer(unittest.TestCase):
                     {
                         "name": "init-container-python",
                         "properties": {
-                            "image": "mcr.microsoft.com/cbl-mariner/distroless/python:3.9-nonroot",
+                            "image": "mcr.microsoft.com/azurelinux/base/python:3.12",
                             "environmentVariables": [
                                 {
                                     "name":"PATH",
@@ -2282,7 +2307,7 @@ class PolicyGeneratingDisableStdioAccess(unittest.TestCase):
                 "metadata": {
                     "description": "Name for the container group"
                 },
-                "defaultValue":"mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0"
+                "defaultValue":"mcr.microsoft.com/azurelinux/distroless/base:3.0"
             },
             "containername": {
                 "type": "string",
@@ -2428,7 +2453,7 @@ class PolicyGeneratingOmitId(unittest.TestCase):
                 "metadata": {
                     "description": "Name for the container group"
                 },
-                "defaultValue":"mcr.microsoft.com/cbl-mariner/distroless/python:3.9-nonroot"
+                "defaultValue":"mcr.microsoft.com/azurelinux/base/python:3.12"
             },
             "containername": {
                 "type": "string",
@@ -2571,7 +2596,7 @@ class PolicyGeneratingAllowElevated(unittest.TestCase):
                 "metadata": {
                     "description": "Name for the container group"
                 },
-                "defaultValue":"mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0"
+                "defaultValue":"mcr.microsoft.com/azurelinux/distroless/base:3.0"
             },
             "containername": {
                 "type": "string",
@@ -2706,7 +2731,7 @@ class PrintExistingPolicy(unittest.TestCase):
             "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
             "contentVersion": "1.0.0.0",
             "variables": {
-                "image": "mcr.microsoft.com/cbl-mariner/distroless/python:3.9-nonroot"
+                "image": "mcr.microsoft.com/azurelinux/base/python:3.12"
             },
 
 
@@ -2846,7 +2871,7 @@ class PrintExistingPolicy(unittest.TestCase):
   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "variables": {
-    "image": "mcr.microsoft.com/cbl-mariner/distroless/python:3.9-nonroot"
+    "image": "mcr.microsoft.com/azurelinux/base/python:3.12"
   },
   "parameters": {
     "containergroupname": {
@@ -3002,7 +3027,7 @@ class PolicyGeneratingArmWildcardEnvs(unittest.TestCase):
             "containers": [
                 {
                     "name": "simple-container",
-                    "containerImage": "mcr.microsoft.com/cbl-mariner/distroless/python:3.9-nonroot",
+                    "containerImage": "mcr.microsoft.com/azurelinux/base/python:3.12",
                     "environmentVariables": [
                         {
                             "name":"PATH",
@@ -3028,7 +3053,7 @@ class PolicyGeneratingArmWildcardEnvs(unittest.TestCase):
         "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
         "contentVersion": "1.0.0.0",
         "variables": {
-            "image": "mcr.microsoft.com/cbl-mariner/distroless/python:3.9-nonroot"
+            "image": "mcr.microsoft.com/azurelinux/base/python:3.12"
         },
 
 
@@ -3146,7 +3171,7 @@ class PolicyGeneratingArmWildcardEnvs(unittest.TestCase):
         "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
         "contentVersion": "1.0.0.0",
         "variables": {
-            "image": "mcr.microsoft.com/cbl-mariner/distroless/python:3.9-nonroot"
+            "image": "mcr.microsoft.com/azurelinux/base/python:3.12"
         },
 
 
@@ -3262,7 +3287,7 @@ class PolicyGeneratingArmWildcardEnvs(unittest.TestCase):
         "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
         "contentVersion": "1.0.0.0",
         "variables": {
-            "image": "mcr.microsoft.com/cbl-mariner/distroless/python:3.9-nonroot"
+            "image": "mcr.microsoft.com/azurelinux/base/python:3.12"
         },
 
 
@@ -3396,7 +3421,7 @@ class PolicyGeneratingArmWildcardEnvs(unittest.TestCase):
         "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
         "contentVersion": "1.0.0.0",
         "variables": {
-            "image": "mcr.microsoft.com/cbl-mariner/distroless/python:3.9-nonroot"
+            "image": "mcr.microsoft.com/azurelinux/base/python:3.12"
         },
 
 
@@ -3541,7 +3566,7 @@ class PolicyGeneratingArmWildcardEnvs(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        with load_policy_from_str(cls.custom_json) as aci_policy:
+        with load_policy_from_json(cls.custom_json) as aci_policy:
             aci_policy.populate_policy_content_for_all_images()
             cls.aci_policy = aci_policy
 
@@ -3651,7 +3676,7 @@ class PolicyGeneratingEdgeCases(unittest.TestCase):
                 "metadata": {
                     "description": "Name for the container group"
                 },
-                "defaultValue":"mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0"
+                "defaultValue":"mcr.microsoft.com/azurelinux/distroless/base:3.0"
             },
             "containername": {
                 "type": "string",
@@ -3779,7 +3804,7 @@ class PolicyGeneratingEdgeCases(unittest.TestCase):
 
         # see if the remote image and the local one produce the same output
         self.assertEqual(env_var, "PORT=parameters('abc')")
-        self.assertEqual(regular_image_json[0][config.POLICY_FIELD_CONTAINERS_ID], "mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0")
+        self.assertEqual(regular_image_json[0][config.POLICY_FIELD_CONTAINERS_ID], "mcr.microsoft.com/azurelinux/distroless/base:3.0")
 
     def test_arm_template_config_map_sidecar(self):
         regular_image_json = json.loads(
@@ -3799,7 +3824,7 @@ class PolicyGeneratingSecurityContext(unittest.TestCase):
         "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
         "contentVersion": "1.0.0.0",
         "variables": {
-            "image": "mcr.microsoft.com/cbl-mariner/distroless/python:3.9-nonroot"
+            "image": "mcr.microsoft.com/azurelinux/base/python:3.12"
         },
 
 
@@ -3940,7 +3965,7 @@ class PolicyGeneratingSecurityContext(unittest.TestCase):
         "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
         "contentVersion": "1.0.0.0",
         "variables": {
-            "image": "mcr.microsoft.com/cbl-mariner/distroless/python:3.9-nonroot"
+            "image": "mcr.microsoft.com/azurelinux/base/python:3.12"
         },
 
 
@@ -4091,7 +4116,7 @@ class PolicyGeneratingSecurityContext(unittest.TestCase):
         "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
         "contentVersion": "1.0.0.0",
         "variables": {
-            "image": "mcr.microsoft.com/cbl-mariner/distroless/python:3.9-nonroot"
+            "image": "mcr.microsoft.com/azurelinux/base/python:3.12"
         },
 
 
@@ -4238,7 +4263,7 @@ class PolicyGeneratingSecurityContext(unittest.TestCase):
         "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
         "contentVersion": "1.0.0.0",
         "variables": {
-            "image": "mcr.microsoft.com/cbl-mariner/distroless/python:3.9-nonroot"
+            "image": "mcr.microsoft.com/azurelinux/base/python:3.12"
         },
 
 
@@ -4407,20 +4432,7 @@ class PolicyGeneratingSecurityContext(unittest.TestCase):
         cls.aci_arm_policy4.populate_policy_content_for_all_images()
 
     def test_arm_template_security_context_defaults(self):
-        expected_user_json = json.loads("""{
-            "user_idname":
-            {
-                "pattern": "nonroot",
-                "strategy": "name"
-            },
-            "group_idnames": [
-                {
-                    "pattern": "",
-                    "strategy": "any"
-                }
-            ],
-            "umask": "0022"
-        }""")
+        expected_user_json = config.DEFAULT_USER
 
         regular_image_json = json.loads(
             self.aci_arm_policy.get_serialized_output(
@@ -4526,7 +4538,7 @@ class PolicyGeneratingSecurityContextUserEdgeCases(unittest.TestCase):
         "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
         "contentVersion": "1.0.0.0",
         "variables": {
-            "image": "mcr.microsoft.com/cbl-mariner/distroless/python:3.9-nonroot"
+            "image": "mcr.microsoft.com/azurelinux/base/python:3.12"
         },
 
 
@@ -4676,7 +4688,7 @@ class PolicyGeneratingSecurityContextUserEdgeCases(unittest.TestCase):
         "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
         "contentVersion": "1.0.0.0",
         "variables": {
-            "image": "mcr.microsoft.com/cbl-mariner/distroless/python:3.9-nonroot"
+            "image": "mcr.microsoft.com/azurelinux/base/python:3.12"
         },
 
 
@@ -5046,7 +5058,7 @@ class PolicyGeneratingSecurityContextUserEdgeCases(unittest.TestCase):
         self.assertEqual(deepdiff.DeepDiff(regular_image_json[0][config.POLICY_FIELD_CONTAINERS_ELEMENTS_USER], expected_user_json, ignore_order=True), {})
 
     def test_arm_template_security_context_uid_gid(self):
-        dockerfile_contents = ["FROM mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0\n", "USER 456:123\n"]
+        dockerfile_contents = ["FROM mcr.microsoft.com/azurelinux/distroless/base:3.0\n", "USER 456:123\n"]
 
         try:
             with open(self.dockerfile_path, "w") as dockerfile:
@@ -5085,7 +5097,7 @@ class PolicyGeneratingSecurityContextUserEdgeCases(unittest.TestCase):
         self.client.images.remove(image[0].attrs.get("Id"))
 
     def test_arm_template_security_context_user_gid(self):
-        dockerfile_contents = ["FROM mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0\n", "USER test_user:123\n"]
+        dockerfile_contents = ["FROM mcr.microsoft.com/azurelinux/distroless/base:3.0\n", "USER test_user:123\n"]
 
         try:
             with open(self.dockerfile_path2, "w") as dockerfile:
@@ -5124,7 +5136,7 @@ class PolicyGeneratingSecurityContextUserEdgeCases(unittest.TestCase):
         self.client.images.remove(image[0].attrs.get("Id"))
 
     def test_arm_template_security_context_user_group(self):
-        dockerfile_contents = ["FROM mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0\n", "USER test_user:test_group\n"]
+        dockerfile_contents = ["FROM mcr.microsoft.com/azurelinux/distroless/base:3.0\n", "USER test_user:test_group\n"]
         try:
             with open(self.dockerfile_path3, "w") as dockerfile:
                 dockerfile.writelines(dockerfile_contents)
@@ -5163,7 +5175,7 @@ class PolicyGeneratingSecurityContextUserEdgeCases(unittest.TestCase):
 
     def test_arm_template_security_context_uid_group(self):
         # valid values are "user", "uid",
-        dockerfile_contents = ["FROM mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0\n", "USER 456:test_group\n"]
+        dockerfile_contents = ["FROM mcr.microsoft.com/azurelinux/distroless/base:3.0\n", "USER 456:test_group\n"]
         try:
             with open(self.dockerfile_path4, "w") as dockerfile:
                 dockerfile.writelines(dockerfile_contents)
@@ -5202,7 +5214,7 @@ class PolicyGeneratingSecurityContextUserEdgeCases(unittest.TestCase):
         self.client.images.remove(image[0].attrs.get("Id"))
 
     def test_arm_template_security_context_uid(self):
-        dockerfile_contents = ["FROM mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0\n", "USER 456\n"]
+        dockerfile_contents = ["FROM mcr.microsoft.com/azurelinux/distroless/base:3.0\n", "USER 456\n"]
         try:
             with open(self.dockerfile_path5, "w") as dockerfile:
                 dockerfile.writelines(dockerfile_contents)
@@ -5240,7 +5252,7 @@ class PolicyGeneratingSecurityContextUserEdgeCases(unittest.TestCase):
         self.client.images.remove(image[0].attrs.get("Id"))
 
     def test_arm_template_security_context_user_dockerfile(self):
-        dockerfile_contents = ["FROM mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0\n", "USER test_user\n"]
+        dockerfile_contents = ["FROM mcr.microsoft.com/azurelinux/distroless/base:3.0\n", "USER test_user\n"]
         try:
             with open(self.dockerfile_path6, "w") as dockerfile:
                 dockerfile.writelines(dockerfile_contents)
@@ -5284,7 +5296,7 @@ class PolicyGeneratingSecurityContextSeccompProfileEdgeCases(unittest.TestCase):
         "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
         "contentVersion": "1.0.0.0",
         "variables": {
-            "image": "mcr.microsoft.com/cbl-mariner/distroless/python:3.9-nonroot"
+            "image": "mcr.microsoft.com/azurelinux/base/python:3.12"
         },
 
 
@@ -5637,7 +5649,7 @@ class PolicyZeroSidecar(unittest.TestCase):
         "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
         "contentVersion": "1.0.0.0",
         "variables": {
-            "image": "mcr.microsoft.com/cbl-mariner/distroless/python:3.9-nonroot"
+            "image": "mcr.microsoft.com/azurelinux/base/python:3.12"
         },
 
 

--- a/src/confcom/azext_confcom/tests/latest/test_confcom_image.py
+++ b/src/confcom/azext_confcom/tests/latest/test_confcom_image.py
@@ -11,7 +11,7 @@ import deepdiff
 from azext_confcom.security_policy import (
     OutputType,
     load_policy_from_image_name,
-    load_policy_from_str,
+    load_policy_from_json,
 )
 from  azext_confcom.template_util import DockerClient
 import azext_confcom.config as config
@@ -25,7 +25,8 @@ class PolicyGeneratingImage(unittest.TestCase):
             "version": "1.0",
             "containers": [
                 {
-                    "containerImage": "mcr.microsoft.com/cbl-mariner/distroless/python:3.9-nonroot",
+                    "name": "mcr.microsoft.com/azurelinux/base/python:3.12",
+                    "containerImage": "mcr.microsoft.com/azurelinux/base/python:3.12",
                     "environmentVariables": [
 
                     ],
@@ -38,10 +39,10 @@ class PolicyGeneratingImage(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        with load_policy_from_image_name("mcr.microsoft.com/cbl-mariner/distroless/python:3.9-nonroot") as aci_policy:
+        with load_policy_from_image_name("mcr.microsoft.com/azurelinux/base/python:3.12") as aci_policy:
             aci_policy.populate_policy_content_for_all_images(individual_image=True)
             cls.aci_policy = aci_policy
-        with load_policy_from_str(cls.custom_json) as custom_policy:
+        with load_policy_from_json(cls.custom_json) as custom_policy:
             custom_policy.populate_policy_content_for_all_images()
             cls.custom_policy = custom_policy
 
@@ -56,6 +57,7 @@ class PolicyGeneratingImageSidecar(unittest.TestCase):
             "version": "1.0",
             "containers": [
                 {
+                    "name": "mcr.microsoft.com/aci/atlas-mount-azure-file-volume:master_20201210.2",
                     "containerImage": "mcr.microsoft.com/aci/atlas-mount-azure-file-volume:master_20201210.2",
                     "environmentVariables": [
 
@@ -76,7 +78,7 @@ class PolicyGeneratingImageSidecar(unittest.TestCase):
         ) as aci_policy:
             aci_policy.populate_policy_content_for_all_images(individual_image=True)
             cls.aci_policy = aci_policy
-        with load_policy_from_str(cls.custom_json) as custom_policy:
+        with load_policy_from_json(cls.custom_json) as custom_policy:
             custom_policy.populate_policy_content_for_all_images(individual_image=True)
             cls.custom_policy = custom_policy
 

--- a/src/confcom/azext_confcom/tests/latest/test_confcom_policy_conversion.py
+++ b/src/confcom/azext_confcom/tests/latest/test_confcom_policy_conversion.py
@@ -1,0 +1,123 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+import copy
+import json
+import unittest
+from typing import Any, Dict
+
+from azext_confcom.template_util import (
+    convert_config_v0_to_v1,
+    detect_old_format,
+)
+import azext_confcom.config as cfg
+
+class ConvertConfigTests(unittest.TestCase):
+    """Tests for the conversion of old-format ACI configs to v1 format.
+
+    This includes:
+    • Old-format detection
+    • Default propagation of top-level fields (`version`, `fragments`)
+    • Environment-variable strategy → `regex` flag mapping
+    • `command` + liveness / readiness probes → `execProcesses` aggregation
+    • Volume-mount translation and naming rules
+    • Migration of `workingDir` and `allow_elevated` into security context
+    • Idempotence when input is already v1
+    """
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls._old_json = """
+        {
+            "version": "1.0",
+            "containers": [{
+                "name": "demo",
+                "containerImage": "demo:latest",
+                "environmentVariables": [
+                    {"name": "FOO", "value": "bar", "strategy": "string"},
+                    {"name": "REGEXP_VAR", "value": "v.*", "strategy": "re2"}
+                ],
+                "command": ["python", "app.py"],
+                "livenessProbe": {"exec": {"command": ["echo", "alive"]}},
+                "readinessProbe": {"exec": {"command": ["echo", "ready"]}},
+                "workingDir": "/work",
+                "allow_elevated": true,
+                "mounts": [{
+                    "mountType": "azureFile",
+                    "mountPath": "/mnt/af",
+                    "readonly": true
+                }]
+            }]
+        }
+        """
+        cls._old_cfg: Dict[str, Any] = json.loads(cls._old_json)
+        cls._new_cfg: Dict[str, Any] = convert_config_v0_to_v1(copy.deepcopy(cls._old_cfg))
+
+    def test_detect_old_format(self) -> None:
+        self.assertTrue(detect_old_format(self._old_cfg))
+        self.assertFalse(detect_old_format(self._new_cfg))
+
+    def test_top_level_fields_propagated(self) -> None:
+        self.assertEqual(self._new_cfg[cfg.ACI_FIELD_VERSION], "1.0")
+        self.assertEqual(self._new_cfg[cfg.ACI_FIELD_CONTAINERS_REGO_FRAGMENTS], [])
+
+    def test_container_count_preserved(self) -> None:
+        self.assertEqual(
+            len(self._new_cfg[cfg.ACI_FIELD_CONTAINERS]),
+            len(self._old_cfg[cfg.ACI_FIELD_CONTAINERS]),
+        )
+
+    def test_env_strategy_to_regex_flag(self) -> None:
+        new_container = self._new_cfg[cfg.ACI_FIELD_CONTAINERS][0]
+        envs = new_container[cfg.ACI_FIELD_TEMPLATE_PROPERTIES][
+            cfg.ACI_FIELD_CONTAINERS_ENVS
+        ]
+
+        string_env = next(e for e in envs if e["name"] == "FOO")
+        self.assertNotIn("regex", string_env)
+
+        regex_env = next(e for e in envs if e["name"] == "REGEXP_VAR")
+        self.assertTrue(regex_env.get("regex", False))
+
+    def test_exec_processes_built_correctly(self) -> None:
+        props = self._new_cfg[cfg.ACI_FIELD_CONTAINERS][0][cfg.ACI_FIELD_TEMPLATE_PROPERTIES]
+
+        # Primary entrypoint stays in `command`
+        self.assertEqual(props[cfg.ACI_FIELD_CONTAINERS_COMMAND], ["python", "app.py"])
+
+        # Only probe commands land in execProcesses
+        proc_cmds = [
+            p[cfg.ACI_FIELD_CONTAINERS_COMMAND]
+            for p in props[cfg.ACI_FIELD_CONTAINERS_EXEC_PROCESSES]
+        ]
+        self.assertCountEqual(proc_cmds, [["echo", "alive"], ["echo", "ready"]])
+        self.assertEqual(len(proc_cmds), 2)
+
+    def test_volume_mount_basic_fields(self) -> None:
+        props = self._new_cfg[cfg.ACI_FIELD_CONTAINERS][0][
+            cfg.ACI_FIELD_TEMPLATE_PROPERTIES
+        ]
+        vm = props[cfg.ACI_FIELD_TEMPLATE_VOLUME_MOUNTS][0]
+
+        self.assertEqual(vm[cfg.ACI_FIELD_CONTAINERS_ENVS_NAME], "azurefile")
+        self.assertEqual(vm[cfg.ACI_FIELD_TEMPLATE_MOUNTS_PATH], "/mnt/af")
+        self.assertEqual(vm[cfg.ACI_FIELD_TEMPLATE_MOUNTS_TYPE], "azureFile")
+        self.assertTrue(vm[cfg.ACI_FIELD_TEMPLATE_MOUNTS_READONLY])
+
+    def test_workingdir_and_allow_elevated_migrated(self) -> None:
+        props = self._new_cfg[cfg.ACI_FIELD_CONTAINERS][0][
+            cfg.ACI_FIELD_TEMPLATE_PROPERTIES
+        ]
+        self.assertEqual(props[cfg.ACI_FIELD_CONTAINERS_WORKINGDIR], "/work")
+        self.assertTrue(
+            props[cfg.ACI_FIELD_TEMPLATE_SECURITY_CONTEXT][
+                cfg.ACI_FIELD_CONTAINERS_PRIVILEGED
+            ]
+        )
+
+    def test_already_v1_returns_same_object(self) -> None:
+        v1_in = {"version": "1.0", "fragments": [], "containers": []}
+        v1_out = convert_config_v0_to_v1(copy.deepcopy(v1_in))
+        self.assertEqual(v1_out, v1_in)

--- a/src/confcom/azext_confcom/tests/latest/test_confcom_scenario.py
+++ b/src/confcom/azext_confcom/tests/latest/test_confcom_scenario.py
@@ -10,7 +10,7 @@ import json
 from azext_confcom.security_policy import (
     UserContainerImage,
     OutputType,
-    load_policy_from_str,
+    load_policy_from_json,
 )
 
 import azext_confcom.config as config
@@ -25,7 +25,8 @@ class MountEnforcement(unittest.TestCase):
         "version": "1.0",
         "containers": [
             {
-                "containerImage": "mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0",
+                "name": "mcr.microsoft.com/azurelinux/distroless/base:3.0",
+                "containerImage": "mcr.microsoft.com/azurelinux/distroless/base:3.0",
                 "environmentVariables": [
                     {
                         "name": "PATH",
@@ -48,7 +49,8 @@ class MountEnforcement(unittest.TestCase):
                 ]
             },
             {
-                "containerImage": "mcr.microsoft.com/cbl-mariner/distroless/python:3.9-nonroot",
+                "name": "mcr.microsoft.com/azurelinux/base/python:3.12",
+                "containerImage": "mcr.microsoft.com/azurelinux/base/python:3.12",
                 "environmentVariables": [],
                 "command": ["echo", "hello"],
                 "workingDir": "/customized/absolute/path",
@@ -64,7 +66,7 @@ class MountEnforcement(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        with load_policy_from_str(cls.custom_json) as aci_policy:
+        with load_policy_from_json(cls.custom_json) as aci_policy:
             aci_policy.populate_policy_content_for_all_images()
             cls.aci_policy = aci_policy
 
@@ -73,7 +75,7 @@ class MountEnforcement(unittest.TestCase):
             (
                 img
                 for img in self.aci_policy.get_images()
-                if isinstance(img, UserContainerImage) and img.base == "mcr.microsoft.com/cbl-mariner/distroless/minimal"
+                if isinstance(img, UserContainerImage) and img.base == "mcr.microsoft.com/azurelinux/distroless/base"
             ),
             None,
         )
@@ -112,7 +114,7 @@ class MountEnforcement(unittest.TestCase):
             (
                 img
                 for img in self.aci_policy.get_images()
-                if isinstance(img, UserContainerImage) and img.base == "mcr.microsoft.com/cbl-mariner/distroless/python"
+                if isinstance(img, UserContainerImage) and img.base == "mcr.microsoft.com/azurelinux/base/python"
             ),
             None,
         )
@@ -154,6 +156,7 @@ class PolicyGenerating(unittest.TestCase):
         "version": "1.0",
         "containers": [
             {
+                "name": "mcr.microsoft.com/aci/msi-atlas-adapter:master_20201203.1",
                 "containerImage": "mcr.microsoft.com/aci/msi-atlas-adapter:master_20201203.1",
                 "environmentVariables": [
                 {
@@ -262,7 +265,7 @@ class PolicyGenerating(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        with load_policy_from_str(cls.custom_json) as aci_policy:
+        with load_policy_from_json(cls.custom_json) as aci_policy:
             aci_policy.populate_policy_content_for_all_images()
             cls.aci_policy = aci_policy
 
@@ -365,7 +368,8 @@ class PolicyGeneratingDebugMode(unittest.TestCase):
         "version": "1.0",
         "containers": [
             {
-                "containerImage": "mcr.microsoft.com/cbl-mariner/distroless/python:3.9-nonroot",
+                "name": "mcr.microsoft.com/azurelinux/base/python:3.12",
+                "containerImage": "mcr.microsoft.com/azurelinux/base/python:3.12",
             "environmentVariables": [
 
             ],
@@ -379,7 +383,7 @@ class PolicyGeneratingDebugMode(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        with load_policy_from_str(cls.custom_json, debug_mode=True) as aci_policy:
+        with load_policy_from_json(cls.custom_json, debug_mode=True) as aci_policy:
             aci_policy.populate_policy_content_for_all_images()
             cls.aci_policy = aci_policy
 
@@ -412,6 +416,7 @@ class SidecarValidation(unittest.TestCase):
     "version": "1.0",
     "containers": [
         {
+            "name": "mcr.microsoft.com/aci/msi-atlas-adapter:master_20201210.1",
             "containerImage": "mcr.microsoft.com/aci/msi-atlas-adapter:master_20201210.1",
             "environmentVariables": [
                 {
@@ -436,6 +441,7 @@ class SidecarValidation(unittest.TestCase):
     "version": "1.0",
     "containers": [
         {
+            "name": "mcr.microsoft.com/aci/msi-atlas-adapter:master_20201210.1",
             "containerImage": "mcr.microsoft.com/aci/msi-atlas-adapter:master_20201210.1",
             "environmentVariables": [
                {"name": "PATH",
@@ -459,10 +465,10 @@ class SidecarValidation(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        with load_policy_from_str(cls.custom_json) as aci_policy:
+        with load_policy_from_json(cls.custom_json) as aci_policy:
             aci_policy.populate_policy_content_for_all_images()
             cls.aci_policy = aci_policy
-        with load_policy_from_str(cls.custom_json2) as aci_policy2:
+        with load_policy_from_json(cls.custom_json2) as aci_policy2:
             aci_policy2.populate_policy_content_for_all_images()
             cls.aci_policy2 = aci_policy2
 
@@ -505,7 +511,8 @@ class CustomJsonParsing(unittest.TestCase):
             "version": "1.0",
             "containers": [
                 {
-                    "containerImage": "mcr.microsoft.com/cbl-mariner/distroless/python:3.9-nonroot",
+                    "name": "mcr.microsoft.com/azurelinux/base/python:3.12",
+                    "containerImage": "mcr.microsoft.com/azurelinux/base/python:3.12",
                     "environmentVariables": [],
                     "command": ["echo", "hello"],
                     "workingDir": "/customized/absolute/path"
@@ -513,7 +520,7 @@ class CustomJsonParsing(unittest.TestCase):
             ]
         }
         """
-        with load_policy_from_str(custom_json) as aci_policy:
+        with load_policy_from_json(custom_json) as aci_policy:
             # pull actual image to local for next step
             image = next(
                 (
@@ -533,7 +540,8 @@ class CustomJsonParsing(unittest.TestCase):
             "version": "1.0",
             "containers": [
                 {
-                    "containerImage": "mcr.microsoft.com/cbl-mariner/distroless/python:3.9-nonroot",
+                    "name": "mcr.microsoft.com/azurelinux/base/python:3.12",
+                    "containerImage": "mcr.microsoft.com/azurelinux/base/python:3.12",
                     "environmentVariables": [],
                     "command": ["echo", "hello"],
                     "workingDir": "/customized/absolute/path",
@@ -542,7 +550,7 @@ class CustomJsonParsing(unittest.TestCase):
             ]
         }
         """
-        with load_policy_from_str(custom_json) as aci_policy:
+        with load_policy_from_json(custom_json) as aci_policy:
             # pull actual image to local for next step
             image = next(
                 (
@@ -562,14 +570,15 @@ class CustomJsonParsing(unittest.TestCase):
             "version": "1.0",
             "containers": [
                 {
-                    "containerImage": "mcr.microsoft.com/cbl-mariner/distroless/python:3.9-nonroot",
+                    "name": "mcr.microsoft.com/azurelinux/base/python:3.12",
+                    "containerImage": "mcr.microsoft.com/azurelinux/base/python:3.12",
                     "environmentVariables": [],
                     "command": ["echo", "hello"]
                 }
             ]
         }
         """
-        with load_policy_from_str(custom_json) as aci_policy:
+        with load_policy_from_json(custom_json) as aci_policy:
             # pull actual image to local for next step
             with DockerClient() as client:
                 image_ref = aci_policy.get_images()[0]
@@ -577,8 +586,9 @@ class CustomJsonParsing(unittest.TestCase):
             aci_policy.populate_policy_content_for_all_images()
             layers = aci_policy.get_images()[0]._layers
             expected_layers = [
-                "81f4183d118e68e8bb3c8845da3b0fe3cc331a63184b534ea0307d4d01c52418",
-                "3a1edaedd7e7e0072846d74219577c05b25498c233196d38ae0fe6cde8c2c92a"
+                "1824eb49720f59202136bd38681f32e57239676c9a423fb1e025aa210aaa22aa",
+                "8d68e2b0c2c32fa7fab2a5543d94e0b70b5bea400ca7f89f4c925a02ae15f453",
+                "44e8e0480dc3c0d04564ba87b3ba851cfab008717abdf6be83baf47963599614"
             ]
             self.assertEqual(len(layers), len(expected_layers))
             for i in range(len(expected_layers)):
@@ -590,14 +600,15 @@ class CustomJsonParsing(unittest.TestCase):
             "version": "1.0",
             "containers": [
                 {
-                    "containerImage": "mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0",
+                    "name": "mcr.microsoft.com/azurelinux/distroless/base:3.0",
+                    "containerImage": "mcr.microsoft.com/azurelinux/distroless/base:3.0",
                     "environmentVariables": [],
                     "command": ["echo", "hello"]
                 }
             ]
         }
         """
-        with load_policy_from_str(custom_json) as aci_policy:
+        with load_policy_from_json(custom_json) as aci_policy:
             with DockerClient() as client:
                 image_ref = aci_policy.get_images()[0]
                 image = client.images.pull(image_ref.base, tag=image_ref.tag)
@@ -605,7 +616,7 @@ class CustomJsonParsing(unittest.TestCase):
 
             self.assertEqual(
                 image.tags[0],
-                "mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0",
+                "mcr.microsoft.com/azurelinux/distroless/base:3.0",
             )
 
     def test_infrastructure_svn(self):
@@ -614,14 +625,15 @@ class CustomJsonParsing(unittest.TestCase):
             "version": "1.0",
             "containers": [
                 {
-                    "containerImage": "mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0",
+                    "name": "mcr.microsoft.com/azurelinux/distroless/base:3.0",
+                    "containerImage": "mcr.microsoft.com/azurelinux/distroless/base:3.0",
                     "environmentVariables": [],
                     "command": ["echo", "hello"]
                 }
             ]
         }
         """
-        with load_policy_from_str(custom_json) as aci_policy:
+        with load_policy_from_json(custom_json) as aci_policy:
             aci_policy.populate_policy_content_for_all_images()
             output = aci_policy.get_serialized_output(OutputType.PRETTY_PRINT)
 
@@ -633,7 +645,8 @@ class CustomJsonParsing(unittest.TestCase):
             "version": "1.0",
             "containers": [
                 {
-                    "containerImage": "mcr.microsoft.com/azuredocs/aci-dataprocessing-cc:v1",
+                    "name": "mcr.microsoft.com/azurelinux/distroless/base:3.0",
+                    "containerImage": "mcr.microsoft.com/azurelinux/distroless/base:3.0",
                     "environmentVariables": [
                         {
                             "name": "env-name1",
@@ -651,7 +664,7 @@ class CustomJsonParsing(unittest.TestCase):
             ]
         }
         """
-        containers = load_policy_from_str(custom_json).get_images()
+        containers = load_policy_from_json(custom_json).get_images()
         self.assertEqual(len(containers), 1)
         envs = containers[0]._environmentRules
         self.assertIsNotNone(envs)
@@ -690,14 +703,15 @@ class CustomJsonParsing(unittest.TestCase):
             "version": "1.0",
             "containers": [
                 {
-                    "containerImage": "mcr.microsoft.com/cbl-mariner/distroless/python:3.9-nonroot",
+                    "name": "mcr.microsoft.com/azurelinux/base/python:3.12",
+                    "containerImage": "mcr.microsoft.com/azurelinux/base/python:3.12",
                     "environmentVariables": [],
                     "command": ["echo", "hello"]
                 }
             ]
         }
         """
-        with load_policy_from_str(custom_json) as aci_policy:
+        with load_policy_from_json(custom_json) as aci_policy:
             aci_policy.populate_policy_content_for_all_images()
             self.assertTrue(
                 json.loads(
@@ -713,7 +727,8 @@ class CustomJsonParsing(unittest.TestCase):
             "version": "1.0",
             "containers": [
                 {
-                    "containerImage": "mcr.microsoft.com/cbl-mariner/distroless/python:3.9-nonroot",
+                    "name": "mcr.microsoft.com/azurelinux/base/python:3.12",
+                    "containerImage": "mcr.microsoft.com/azurelinux/base/python:3.12",
                     "environmentVariables": [],
                     "command": ["echo", "hello"],
                     "allowStdioAccess": false
@@ -721,7 +736,7 @@ class CustomJsonParsing(unittest.TestCase):
             ]
         }
         """
-        with load_policy_from_str(custom_json) as aci_policy:
+        with load_policy_from_json(custom_json, disable_stdio=True) as aci_policy:
             aci_policy.populate_policy_content_for_all_images()
 
             self.assertFalse(
@@ -733,12 +748,13 @@ class CustomJsonParsing(unittest.TestCase):
             )
 
     def test_omit_id(self):
-        image_name = "mcr.microsoft.com/cbl-mariner/distroless/python:3.9-nonroot"
+        image_name = "mcr.microsoft.com/azurelinux/base/python:3.12"
         custom_json = f"""
         {{
             "version": "1.0",
             "containers": [
                 {{
+                    "name": "{image_name}",
                     "containerImage": "{image_name}",
                     "environmentVariables": [],
                     "command": ["echo", "hello"],
@@ -747,7 +763,7 @@ class CustomJsonParsing(unittest.TestCase):
             ]
         }}
         """
-        with load_policy_from_str(custom_json) as aci_policy:
+        with load_policy_from_json(custom_json) as aci_policy:
             aci_policy.populate_policy_content_for_all_images()
 
             self.assertIsNone(
@@ -776,6 +792,7 @@ class CustomJsonParsingIncorrect(unittest.TestCase):
             "version": "1.0",
             "containers": [
                 {
+                    "name": "fake-name",
                     "containerImage": "notexists:1.0.0",
                     "environmentVariables": [],
                     "command": ["echo", "hello"]
@@ -783,7 +800,7 @@ class CustomJsonParsingIncorrect(unittest.TestCase):
             ]
         }
         """
-        with load_policy_from_str(custom_json) as aci_policy:
+        with load_policy_from_json(custom_json) as aci_policy:
             with self.assertRaises(SystemExit) as exc_info:
                 aci_policy.populate_policy_content_for_all_images()
             self.assertEqual(exc_info.exception.code, 1)
@@ -794,7 +811,8 @@ class CustomJsonParsingIncorrect(unittest.TestCase):
             "version": "1.0",
             "containers": [
                 {
-                    "containerImage": "mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0",
+                    "name": "mcr.microsoft.com/azurelinux/distroless/base:3.0",
+                    "containerImage": "mcr.microsoft.com/azurelinux/distroless/base:3.0",
                     "environmentVariables": [],
                     "command": "echo hello",
                     "workingDir": "relative/string/path",
@@ -805,7 +823,7 @@ class CustomJsonParsingIncorrect(unittest.TestCase):
         """
         # allow_elevated can only be a boolean
         with self.assertRaises(SystemExit) as exc_info:
-            load_policy_from_str(custom_json)
+            load_policy_from_json(custom_json)
         self.assertEqual(exc_info.exception.code, 1)
 
     def test_incorrect_workingdir_path(self):
@@ -814,7 +832,8 @@ class CustomJsonParsingIncorrect(unittest.TestCase):
             "version": "1.0",
             "containers": [
                 {
-                    "containerImage": "mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0",
+                    "name": "mcr.microsoft.com/azurelinux/distroless/base:3.0",
+                    "containerImage": "mcr.microsoft.com/azurelinux/distroless/base:3.0",
                     "environmentVariables": [],
                     "command": "echo hello",
                     "workingDir": "relative/string/path"
@@ -824,7 +843,7 @@ class CustomJsonParsingIncorrect(unittest.TestCase):
         """
         # workingDir can only be absolute path string
         with self.assertRaises(SystemExit) as exc_info:
-            load_policy_from_str(custom_json)
+            load_policy_from_json(custom_json)
         self.assertEqual(exc_info.exception.code, 1)
 
     def test_incorrect_workingdir_data_type(self):
@@ -833,7 +852,8 @@ class CustomJsonParsingIncorrect(unittest.TestCase):
             "version": "1.0",
             "containers": [
                 {
-                    "containerImage": "mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0",
+                    "name": "mcr.microsoft.com/azurelinux/distroless/base:3.0",
+                    "containerImage": "mcr.microsoft.com/azurelinux/distroless/base:3.0",
                     "environmentVariables": [],
                     "command": "echo hello",
                     "workingDir": ["hello"]
@@ -843,7 +863,7 @@ class CustomJsonParsingIncorrect(unittest.TestCase):
         """
         # workingDir can only be single string
         with self.assertRaises(SystemExit) as exc_info:
-            load_policy_from_str(custom_json)
+            load_policy_from_json(custom_json)
         self.assertEqual(exc_info.exception.code, 1)
 
     def test_incorrect_command_data_type(self):
@@ -852,7 +872,8 @@ class CustomJsonParsingIncorrect(unittest.TestCase):
             "version": "1.0",
             "containers": [
                 {
-                    "containerImage": "mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0",
+                    "name": "mcr.microsoft.com/azurelinux/distroless/base:3.0",
+                    "containerImage": "mcr.microsoft.com/azurelinux/distroless/base:3.0",
                     "environmentVariables": [],
                     "command": "echo hello"
                 }
@@ -861,7 +882,7 @@ class CustomJsonParsingIncorrect(unittest.TestCase):
         """
         # command can only be list of strings
         with self.assertRaises(SystemExit) as exc_info:
-            load_policy_from_str(custom_json)
+            load_policy_from_json(custom_json)
         self.assertEqual(exc_info.exception.code, 1)
 
     def test_json_missing_containers(self):
@@ -871,7 +892,7 @@ class CustomJsonParsingIncorrect(unittest.TestCase):
         }
         """
         with self.assertRaises(SystemExit) as exc_info:
-            load_policy_from_str(custom_json)
+            load_policy_from_json(custom_json)
         self.assertEqual(exc_info.exception.code, 1)
 
     def test_json_missing_containerImage(self):
@@ -880,6 +901,7 @@ class CustomJsonParsingIncorrect(unittest.TestCase):
             "version": "1.0",
             "containers": [
                 {
+                    "name": "mcr.microsoft.com/azurelinux/distroless/base:3.0",
                     "environmentVariables": [
                         {
                             "name": "port",
@@ -893,7 +915,7 @@ class CustomJsonParsingIncorrect(unittest.TestCase):
         }
         """
         with self.assertRaises(SystemExit) as exc_info:
-            load_policy_from_str(custom_json)
+            load_policy_from_json(custom_json)
         self.assertEqual(exc_info.exception.code, 1)
 
     def test_json_missing_environmentVariables(self):
@@ -902,15 +924,24 @@ class CustomJsonParsingIncorrect(unittest.TestCase):
             "version": "1.0",
             "containers": [
                 {
-                    "containerImage": "mcr.microsoft.com/azuredocs/aci-dataprocessing-cc:v1",
+                    "name": "mcr.microsoft.com/azurelinux/distroless/base:3.0",
+                    "containerImage": "mcr.microsoft.com/azurelinux/distroless/base:3.0",
                     "command": ["python", "app.py"]
                 }
             ]
         }
         """
-        with self.assertRaises(SystemExit) as exc_info:
-            load_policy_from_str(custom_json)
-        self.assertEqual(exc_info.exception.code, 1)
+        with load_policy_from_json(custom_json) as aci_policy:
+            aci_policy.populate_policy_content_for_all_images()
+
+            self.assertIsNotNone(
+                json.loads(
+                    aci_policy.get_serialized_output(
+                        output_type=OutputType.RAW, rego_boilerplate=False, omit_id=True
+                    )
+                )[0].get(config.POLICY_FIELD_CONTAINERS_ELEMENTS_ENVS)
+            )
+
 
     def test_json_missing_command(self):
         custom_json = """
@@ -918,7 +949,8 @@ class CustomJsonParsingIncorrect(unittest.TestCase):
             "version": "1.0",
             "containers": [
                 {
-                    "containerImage": "mcr.microsoft.com/azuredocs/aci-dataprocessing-cc:v1",
+                    "name": "mcr.microsoft.com/aci/msi-atlas-adapter:master_20201210.1",
+                    "containerImage": "mcr.microsoft.com/aci/msi-atlas-adapter:master_20201210.1",
                     "environmentVariables": [
                         {
                             "name": "port",
@@ -930,6 +962,15 @@ class CustomJsonParsingIncorrect(unittest.TestCase):
             ]
         }
         """
-        with self.assertRaises(SystemExit) as exc_info:
-            load_policy_from_str(custom_json)
-        self.assertEqual(exc_info.exception.code, 1)
+        with load_policy_from_json(custom_json) as aci_policy:
+            aci_policy.populate_policy_content_for_all_images()
+
+            self.assertIsNotNone(
+                json.loads(
+                    aci_policy.get_serialized_output(
+                        output_type=OutputType.RAW, rego_boilerplate=False, omit_id=True
+                    )
+                )[0].get(config.POLICY_FIELD_CONTAINERS_ELEMENTS_COMMANDS)
+            )
+
+

--- a/src/confcom/azext_confcom/tests/latest/test_confcom_tar.py
+++ b/src/confcom/azext_confcom/tests/latest/test_confcom_tar.py
@@ -428,7 +428,7 @@ class PolicyGeneratingArmParametersCleanRoomTarFile(unittest.TestCase):
                 "metadata": {
                     "description": "Name for the container group"
                 },
-                "defaultValue":"mcr.microsoft.com/cbl-mariner/distroless/python:3.9-nonroot"
+                "defaultValue":"mcr.microsoft.com/azurelinux/base/python:3.12"
             },
             "containername2": {
                 "type": "string",
@@ -572,7 +572,7 @@ class PolicyGeneratingArmParametersCleanRoomTarFile(unittest.TestCase):
 
         filename = os.path.join(self.path, "./mariner2.tar")
         create_tar_file(filename)
-        image_mapping = {"mcr.microsoft.com/cbl-mariner/distroless/python:3.9-nonroot": filename}
+        image_mapping = {"mcr.microsoft.com/azurelinux/base/python:3.12": filename}
 
         # check to make sure many:1 mapping doesn't work
         with self.assertRaises(SystemExit) as exc_info:
@@ -624,7 +624,7 @@ class PolicyGeneratingArmParametersCleanRoomTarFile(unittest.TestCase):
                 "metadata": {
                     "description": "Name for the container group"
                 },
-                "defaultValue":"mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0"
+                "defaultValue":"mcr.microsoft.com/azurelinux/distroless/base:3.0"
             },
             "containername": {
                 "type": "string",
@@ -766,7 +766,7 @@ class PolicyGeneratingArmParametersCleanRoomTarFile(unittest.TestCase):
                 "metadata": {
                     "description": "Name for the container group"
                 },
-                "defaultValue":"mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0"
+                "defaultValue":"mcr.microsoft.com/azurelinux/distroless/base:3.0"
             },
             "containername": {
                 "type": "string",

--- a/src/confcom/azext_confcom/tests/latest/test_confcom_template_util.py
+++ b/src/confcom/azext_confcom/tests/latest/test_confcom_template_util.py
@@ -350,7 +350,7 @@ LmZyYW1ld29yay5lcnJvcnN9Cg=="""
             "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
             "contentVersion": "1.0.0.0",
             "variables": {
-                "image": "mcr.microsoft.com/cbl-mariner/distroless/python:3.9-nonroot"
+                "image": "mcr.microsoft.com/azurelinux/base/python:3.12"
             },
 
 

--- a/src/confcom/samples/config.json
+++ b/src/confcom/samples/config.json
@@ -14,7 +14,7 @@
         {
             "name": "my-image",
             "properties": {
-                "image": "mcr.microsoft.com/acc/samples/aci/helloworld:2.8",
+                "image": "mcr.microsoft.com/acc/samples/aci/helloworld:2.9",
                 "execProcesses": [
                     {
                         "command": [

--- a/src/confcom/samples/contoso.rego
+++ b/src/confcom/samples/contoso.rego
@@ -3,7 +3,25 @@ package contoso
 svn := "1"
 framework_version := "0.2.3"
 
-fragments := []
+fragments := [
+  {
+    "feed": "contoso.azurecr.io/infra",
+    "includes": [
+      "containers"
+    ],
+    "issuer": "did:x509:0:sha256:I__iuL25oXEVFdTP_aBLx_eT1RPHbCQ_ECBQfYZpt9s::eku:1.3.6.1.4.1.311.76.59.1.3",
+    "minimum_svn": "1"
+  },
+  {
+    "feed": "mcr.microsoft.com/aci/aci-cc-infra-fragment",
+    "includes": [
+      "containers",
+      "fragments"
+    ],
+    "issuer": "did:x509:0:sha256:I__iuL25oXEVFdTP_aBLx_eT1RPHbCQ_ECBQfYZpt9s::eku:1.3.6.1.4.1.311.76.59.1.3",
+    "minimum_svn": "1"
+  }
+]
 
 containers := [
   {
@@ -67,14 +85,14 @@ containers := [
     ],
     "env_rules": [
       {
+        "pattern": "PATH=/customized/path/value",
+        "required": false,
+        "strategy": "string"
+      },
+      {
         "pattern": "TEST_REGEXP_ENV=test_regexp_env(.*)",
         "required": false,
         "strategy": "re2"
-      },
-      {
-        "pattern": "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
-        "required": false,
-        "strategy": "string"
       },
       {
         "pattern": "PYTHONUNBUFFERED=1",
@@ -132,14 +150,24 @@ containers := [
         "strategy": "re2"
       }
     ],
-    "exec_processes": [],
-    "id": "mcr.microsoft.com/acc/samples/aci/helloworld:2.8",
+    "exec_processes": [
+      {
+        "command": [
+          "echo",
+          "Hello World"
+        ],
+        "signals": []
+      }
+    ],
+    "id": "mcr.microsoft.com/acc/samples/aci/helloworld:2.9",
     "layers": [
-      "0de62d1aaa53f09c1ba26871cc97bda0ed29ea2eba4eb95c42b800159f0c087c",
-      "1db0e60df71bbeda66196a3b518967cbc1b650cda08ada110744e0e07c965a5a",
-      "e5c725f6ef8eae5de23753c9af8ca5489153eecd12982a0db0fc13d93fc7e124",
-      "fdafe8a7071ca0af2ec45276bd7c4abe8aa3068b1fef08856251cf19638c52f2",
-      "398208096568e4d3b1f7e420038c23d2bd3ba0a6c6b21b0f0d8f61c04d796bd7"
+      "4e74440c7b0e6e6c1cc9e6eb9b779e1ffde807122ed8a16bb0422a1d64fd5aa8",
+      "4cf856bcde8e1fa71f57d2218e21dd7c1a6a12c6d930d2bdb4bdb13a46fed9e4",
+      "41a52f45506177737caec5d57fe6160b6c8942dcac1bc7834fc0e94e62ff6b4d",
+      "b8ea8eae7795453b5e3dcfafe3f11fb2d68efb1062308e4d2411d44dd19fa97c",
+      "a0df1939f552483286c45204e7f583c9a6146963a79556fe22578d7b7e63e7a1",
+      "3ccbd6b119e951f3f2586339e9d10168b064a5852fd87cfae94af47a89f4d6c6",
+      "8348c9d4357db6a600aa4c5116ed9755a230d274096706a7d214c02105d0b256"
     ],
     "mounts": [
       {
@@ -147,7 +175,7 @@ containers := [
         "options": [
           "rbind",
           "rshared",
-          "rw"
+          "ro"
         ],
         "source": "sandbox:///tmp/atlas/azureFileVolume/.+",
         "type": "bind"
@@ -163,6 +191,7 @@ containers := [
         "type": "bind"
       }
     ],
+    "name": "my-image",
     "no_new_privileges": false,
     "seccomp_profile_sha256": "",
     "signals": [],
@@ -180,98 +209,5 @@ containers := [
       }
     },
     "working_dir": "/app"
-  },
-  {
-    "allow_elevated": false,
-    "allow_stdio_access": true,
-    "capabilities": {
-      "ambient": [],
-      "bounding": [
-        "CAP_CHOWN",
-        "CAP_DAC_OVERRIDE",
-        "CAP_FSETID",
-        "CAP_FOWNER",
-        "CAP_MKNOD",
-        "CAP_NET_RAW",
-        "CAP_SETGID",
-        "CAP_SETUID",
-        "CAP_SETFCAP",
-        "CAP_SETPCAP",
-        "CAP_NET_BIND_SERVICE",
-        "CAP_SYS_CHROOT",
-        "CAP_KILL",
-        "CAP_AUDIT_WRITE"
-      ],
-      "effective": [
-        "CAP_CHOWN",
-        "CAP_DAC_OVERRIDE",
-        "CAP_FSETID",
-        "CAP_FOWNER",
-        "CAP_MKNOD",
-        "CAP_NET_RAW",
-        "CAP_SETGID",
-        "CAP_SETUID",
-        "CAP_SETFCAP",
-        "CAP_SETPCAP",
-        "CAP_NET_BIND_SERVICE",
-        "CAP_SYS_CHROOT",
-        "CAP_KILL",
-        "CAP_AUDIT_WRITE"
-      ],
-      "inheritable": [],
-      "permitted": [
-        "CAP_CHOWN",
-        "CAP_DAC_OVERRIDE",
-        "CAP_FSETID",
-        "CAP_FOWNER",
-        "CAP_MKNOD",
-        "CAP_NET_RAW",
-        "CAP_SETGID",
-        "CAP_SETUID",
-        "CAP_SETFCAP",
-        "CAP_SETPCAP",
-        "CAP_NET_BIND_SERVICE",
-        "CAP_SYS_CHROOT",
-        "CAP_KILL",
-        "CAP_AUDIT_WRITE"
-      ]
-    },
-    "command": [
-      "/pause"
-    ],
-    "env_rules": [
-      {
-        "pattern": "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
-        "required": true,
-        "strategy": "string"
-      },
-      {
-        "pattern": "TERM=xterm",
-        "required": false,
-        "strategy": "string"
-      }
-    ],
-    "exec_processes": [],
-    "layers": [
-      "16b514057a06ad665f92c02863aca074fd5976c755d26bff16365299169e8415"
-    ],
-    "mounts": [],
-    "no_new_privileges": false,
-    "seccomp_profile_sha256": "",
-    "signals": [],
-    "user": {
-      "group_idnames": [
-        {
-          "pattern": "",
-          "strategy": "any"
-        }
-      ],
-      "umask": "0022",
-      "user_idname": {
-        "pattern": "",
-        "strategy": "any"
-      }
-    },
-    "working_dir": "/"
   }
 ]


### PR DESCRIPTION
`load_policy_from_config_str` and `load_policy_from_str` were somewhat redundant but used different formats. Now there's a translation function `convert_old_format_to_new_format` and a single `load_policy_from_pure_json` so all code goes down the same path.

This also fixes a bug where policy generation would not recognize the `scenario` flag because it was only implemented for fragments.